### PR TITLE
  feat: combine post body and comments into unified split view

### DIFF
--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -49,7 +49,6 @@ class GrokFeedApp(App):
         Binding("down", "cursor_down", "Down", show=False),
         Binding("up", "cursor_up", "Up", show=False),
         Binding("enter", "open_or_body", "Open", priority=True),
-        Binding("c", "open_comments", "Comments"),
         Binding("f", "cycle_source", "Filter"),
         Binding("r", "refresh", "Refresh"),
         Binding("q", "quit", "Quit"),
@@ -113,7 +112,7 @@ class GrokFeedApp(App):
         loading.display = False
         feed.display = True
         count = len(items)
-        self._set_status(f"{count} stories loaded  •  Enter/c = open  •  f = filter  •  r = refresh")
+        self._set_status(f"{count} stories loaded  •  Enter = open  •  f = filter  •  r = refresh")
 
     def _apply_filter(self) -> None:
         feed = self.query_one(FeedList)
@@ -135,13 +134,6 @@ class GrokFeedApp(App):
     def action_open_or_body(self) -> None:
         feed = self.query_one(FeedList)
         item = feed.current_item()
-        if not item:
-            return
-        color = get_source_color(item["source"], 0)
-        self.push_screen(PostSplitModal(item, color))
-
-    def action_open_comments(self) -> None:
-        item = self.query_one(FeedList).current_item()
         if not item:
             return
         color = get_source_color(item["source"], 0)

--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -13,8 +13,7 @@ from .sources.hn import fetch_hn_stories
 from .sources.reddit import fetch_reddit_posts
 from .sources.lobsters import fetch_lobsters_posts
 from .widgets.feed import FeedList
-from .widgets.content_modal import ContentModal
-from .widgets.comments_modal import CommentsModal
+from .widgets.post_split_modal import PostSplitModal
 from .widgets.story import source_color as get_source_color
 
 # Source filter sentinel
@@ -114,7 +113,7 @@ class GrokFeedApp(App):
         loading.display = False
         feed.display = True
         count = len(items)
-        self._set_status(f"{count} stories loaded  •  Enter = open  •  c = comments  •  f = filter  •  r = refresh")
+        self._set_status(f"{count} stories loaded  •  Enter/c = open  •  f = filter  •  r = refresh")
 
     def _apply_filter(self) -> None:
         feed = self.query_one(FeedList)
@@ -138,19 +137,15 @@ class GrokFeedApp(App):
         item = feed.current_item()
         if not item:
             return
-        body = item.get("body", "")
-        if body:
-            color = get_source_color(item["source"], 0)
-            self.push_screen(ContentModal(item, color))
-        elif item.get("url"):
-            self.open_url(item["url"])
+        color = get_source_color(item["source"], 0)
+        self.push_screen(PostSplitModal(item, color))
 
     def action_open_comments(self) -> None:
         item = self.query_one(FeedList).current_item()
         if not item:
             return
         color = get_source_color(item["source"], 0)
-        self.push_screen(CommentsModal(item, color))
+        self.push_screen(PostSplitModal(item, color))
 
     def action_refresh(self) -> None:
         self._source_filter = ALL

--- a/grokfeed/widgets/post_split_modal.py
+++ b/grokfeed/widgets/post_split_modal.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, ScrollableContainer, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Label, Markdown, Static
+
+from ..sources.comments import Comment
+
+INDENT = "  "
+
+
+class CommentWidget(Static):
+    DEFAULT_CSS = """
+    CommentWidget {
+        padding: 0 1;
+        border-bottom: solid $surface-darken-2;
+        height: auto;
+    }
+    """
+
+    def __init__(self, comment: Comment, source_color: str, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._comment = comment
+        self._source_color = source_color
+
+    def render(self) -> str:
+        c = self._comment
+        pad = INDENT * c.depth
+        score = f"▲{c.score}" if c.score != 0 else ""
+        header = f"[bold {self._source_color}]{pad}{c.author}[/]  [dim]{score}[/]"
+        body_lines = c.body.replace("\r", "").split("\n")
+        body = "\n".join(f"{pad}{line}" for line in body_lines if line.strip())
+        return f"{header}\n{body}\n"
+
+
+class PostSplitModal(ModalScreen):
+    """Post body (left) + comments (right) in one compact view."""
+
+    BINDINGS = [
+        Binding("q", "dismiss", "Close"),
+        Binding("escape", "dismiss", "Close", show=False),
+        Binding("tab", "switch_pane", "Switch pane"),
+        Binding("o", "open_url", "Open URL"),
+        Binding("j", "scroll_down", "↓"),
+        Binding("k", "scroll_up", "↑"),
+        Binding("down", "scroll_down", "↓", show=False),
+        Binding("up", "scroll_up", "↑", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    PostSplitModal {
+        align: center middle;
+    }
+    PostSplitModal > Vertical {
+        width: 96%;
+        height: 90%;
+        background: $surface;
+        border: thick $primary;
+    }
+    PostSplitModal #split-header {
+        height: auto;
+        text-style: bold;
+        padding: 1 1;
+        border-bottom: solid $primary-darken-2;
+    }
+    PostSplitModal #split-body {
+        height: 1fr;
+    }
+    PostSplitModal #post-panel {
+        width: 45%;
+        border-right: solid $primary-darken-2;
+    }
+    PostSplitModal #comments-panel {
+        width: 55%;
+    }
+    PostSplitModal #post-scroll {
+        height: 1fr;
+        padding: 0 1;
+    }
+    PostSplitModal #comments-scroll {
+        height: 1fr;
+        padding: 0 1;
+    }
+    PostSplitModal .pane-label {
+        height: 1;
+        color: $text-muted;
+        padding: 0 1;
+        border-bottom: solid $surface-darken-2;
+    }
+    PostSplitModal #modal-hint {
+        height: 1;
+        color: $text-muted;
+        border-top: solid $primary-darken-2;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(self, item: dict, source_color: str) -> None:
+        super().__init__()
+        self._item = item
+        self._source_color = source_color
+        self._active_pane = "post"
+
+    def compose(self) -> ComposeResult:
+        n = self._item.get("comments", 0)
+        body = self._item.get("body", "")
+        url = self._item.get("url", "")
+        with Vertical():
+            yield Label(
+                f"[bold {self._source_color}]{self._item['title']}[/]\n"
+                f"[dim]{self._item['source']}  •  ▲{self._item['score']}  •  {n} comments[/]",
+                id="split-header",
+            )
+            with Horizontal(id="split-body"):
+                with Vertical(id="post-panel"):
+                    yield Label("▶ POST", id="pane-label-post", classes="pane-label")
+                    with ScrollableContainer(id="post-scroll"):
+                        if body:
+                            yield Markdown(body)
+                        elif url:
+                            yield Label(f"[dim]Link post[/]\n\n{url}")
+                        else:
+                            yield Label("[dim]No content.[/]")
+                with Vertical(id="comments-panel"):
+                    yield Label("  COMMENTS", id="pane-label-comments", classes="pane-label")
+                    with ScrollableContainer(id="comments-scroll"):
+                        yield Label("Fetching comments…", id="loading-comments")
+            yield Label(
+                "q close  •  Tab switch pane  •  j/k scroll  •  o open URL",
+                id="modal-hint",
+            )
+
+    def on_mount(self) -> None:
+        self.run_worker(self._load_comments(), exclusive=True)
+
+    async def _load_comments(self) -> None:
+        from ..sources.comments import fetch_comments
+
+        loading = self.query_one("#loading-comments")
+        scroll = self.query_one("#comments-scroll", ScrollableContainer)
+
+        try:
+            comments = await fetch_comments(self._item)
+        except Exception as e:
+            loading.update(f"[red]Error: {e}[/]")
+            return
+
+        await loading.remove()
+
+        if not comments:
+            await scroll.mount(Label("[dim]  No comments.[/]"))
+            return
+
+        for c in comments:
+            await scroll.mount(CommentWidget(c, self._source_color))
+
+    def action_switch_pane(self) -> None:
+        self._active_pane = "comments" if self._active_pane == "post" else "post"
+        if self._active_pane == "post":
+            self.query_one("#pane-label-post", Label).update("▶ POST")
+            self.query_one("#pane-label-comments", Label).update("  COMMENTS")
+        else:
+            self.query_one("#pane-label-post", Label).update("  POST")
+            self.query_one("#pane-label-comments", Label).update("▶ COMMENTS")
+
+    def action_scroll_down(self) -> None:
+        scroll_id = "post-scroll" if self._active_pane == "post" else "comments-scroll"
+        self.query_one(f"#{scroll_id}", ScrollableContainer).scroll_down()
+
+    def action_scroll_up(self) -> None:
+        scroll_id = "post-scroll" if self._active_pane == "post" else "comments-scroll"
+        self.query_one(f"#{scroll_id}", ScrollableContainer).scroll_up()
+
+    def action_open_url(self) -> None:
+        url = self._item.get("url")
+        if url:
+            self.app.open_url(url)
+
+    def action_dismiss(self) -> None:
+        self.dismiss()


### PR DESCRIPTION
  ## Summary

  Replaces the separate `ContentModal` and `CommentsModal` screens with a
  single `PostSplitModal` that shows the post on the left and comments on
  the right in one compact view.

  ## Changes

  - Add `widgets/post_split_modal.py` — new `PostSplitModal` screen with
    a 45/55 left/right split; post body (or URL for link posts) on the
    left, async-loaded comments on the right
  - Remove `c` binding — `Enter` is the single key to open the view
  - Remove `action_open_comments` from `GrokFeedApp` — no longer needed
  - Update status bar hint text

  ## Interaction

  | Key | Action |
  |-----|--------|
  | `Enter` | Open split view |
  | `Tab` | Switch active pane |
  | `j` / `k` | Scroll active pane |
  | `o` | Open URL in browser |
  | `q` / `Esc` | Close |

  Active pane indicated by `▶` prefix in panel header. Comments load
  asynchronously after modal opens.