### PR TITLE
 perf: reduce startup time and install footprint

### DIFF
--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+import httpx
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.widgets import Footer, Header, LoadingIndicator, Label, ListView
 from textual.containers import Container
 
-from .config import Config
+from .config import Config, load_cache, save_cache
 from .sources.hn import fetch_hn_stories
 from .sources.reddit import fetch_reddit_posts
 from .sources.lobsters import fetch_lobsters_posts
@@ -77,21 +78,39 @@ class GrokFeedApp(App):
         self.run_worker(self._load_all(), exclusive=True, name="fetch")
 
     async def _load_all(self) -> None:
-        self._set_status("Fetching stories…")
         loading = self.query_one("#loading")
         feed = self.query_one(FeedList)
         loading.display = True
         feed.display = False
 
+        # Serve from cache if fresh enough
+        cached = load_cache(self.config.cache_ttl_minutes)
+        if cached:
+            self._all_items = cached
+            self._sources = [ALL] + list(dict.fromkeys(i["source"] for i in cached))
+            self._apply_filter()
+            loading.display = False
+            feed.display = True
+            self._set_status(
+                f"{len(cached)} stories (cached)  •  Enter = open  •  f = filter  •  r = refresh"
+            )
+            return
+
+        self._set_status("Fetching stories…")
         try:
-            hn_task = asyncio.create_task(fetch_hn_stories(self.config.hn_story_count))
-            reddit_task = asyncio.create_task(
-                fetch_reddit_posts(self.config.subreddits, self.config.reddit_post_count)
-            )
-            lobsters_task = asyncio.create_task(fetch_lobsters_posts(self.config.lobsters_post_count))
-            hn_stories, reddit_posts, lobsters_posts = await asyncio.gather(
-                hn_task, reddit_task, lobsters_task
-            )
+            async with httpx.AsyncClient() as client:
+                hn_task = asyncio.create_task(
+                    fetch_hn_stories(self.config.hn_story_count, client)
+                )
+                reddit_task = asyncio.create_task(
+                    fetch_reddit_posts(self.config.subreddits, self.config.reddit_post_count, client)
+                )
+                lobsters_task = asyncio.create_task(
+                    fetch_lobsters_posts(self.config.lobsters_post_count, client)
+                )
+                hn_stories, reddit_posts, lobsters_posts = await asyncio.gather(
+                    hn_task, reddit_task, lobsters_task
+                )
         except Exception as e:
             self._set_status(f"Error: {e}")
             loading.display = False
@@ -108,6 +127,7 @@ class GrokFeedApp(App):
         self._all_items = items
         self._sources = [ALL] + list(dict.fromkeys(i["source"] for i in items))
         self._apply_filter()
+        save_cache(items)
 
         loading.display = False
         feed.display = True

--- a/grokfeed/config.py
+++ b/grokfeed/config.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
+import json
 import time
-
-import orjson
 
 try:
     import tomllib
@@ -55,7 +54,7 @@ def load_cache(ttl_minutes: int) -> list[dict] | None:
     if not CACHE_PATH.exists():
         return None
     try:
-        data = orjson.loads(CACHE_PATH.read_bytes())
+        data = json.loads(CACHE_PATH.read_bytes())
         if time.time() - data["ts"] > ttl_minutes * 60:
             return None
         return data["items"]
@@ -66,6 +65,6 @@ def load_cache(ttl_minutes: int) -> list[dict] | None:
 def save_cache(items: list[dict]) -> None:
     try:
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-        CACHE_PATH.write_bytes(orjson.dumps({"ts": time.time(), "items": items}))
+        CACHE_PATH.write_text(json.dumps({"ts": time.time(), "items": items}))
     except Exception:
         pass

--- a/grokfeed/config.py
+++ b/grokfeed/config.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import json
 import time
+
+import orjson
 
 try:
     import tomllib
@@ -54,7 +55,7 @@ def load_cache(ttl_minutes: int) -> list[dict] | None:
     if not CACHE_PATH.exists():
         return None
     try:
-        data = json.loads(CACHE_PATH.read_text())
+        data = orjson.loads(CACHE_PATH.read_bytes())
         if time.time() - data["ts"] > ttl_minutes * 60:
             return None
         return data["items"]
@@ -65,6 +66,6 @@ def load_cache(ttl_minutes: int) -> list[dict] | None:
 def save_cache(items: list[dict]) -> None:
     try:
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-        CACHE_PATH.write_text(json.dumps({"ts": time.time(), "items": items}))
+        CACHE_PATH.write_bytes(orjson.dumps({"ts": time.time(), "items": items}))
     except Exception:
         pass

--- a/grokfeed/config.py
+++ b/grokfeed/config.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import time
+
 try:
     import tomllib
 except ModuleNotFoundError:
@@ -9,12 +12,14 @@ from pathlib import Path
 
 CONFIG_DIR = Path.home() / ".grokfeed"
 CONFIG_PATH = CONFIG_DIR / "config.toml"
+CACHE_PATH = CONFIG_DIR / "cache.json"
 
 DEFAULT_CONFIG = """\
 subreddits = ["programming", "ClaudeAI", "machinelearning"]
 hn_story_count = 30
 reddit_post_count = 15
 lobsters_post_count = 25
+cache_ttl_minutes = 10
 """
 
 
@@ -24,6 +29,7 @@ class Config:
     hn_story_count: int = 30
     reddit_post_count: int = 15
     lobsters_post_count: int = 25
+    cache_ttl_minutes: int = 10
 
 
 def load_config() -> tuple[Config, bool]:
@@ -40,4 +46,25 @@ def load_config() -> tuple[Config, bool]:
         hn_story_count=int(raw.get("hn_story_count", 30)),
         reddit_post_count=int(raw.get("reddit_post_count", 15)),
         lobsters_post_count=int(raw.get("lobsters_post_count", 25)),
+        cache_ttl_minutes=int(raw.get("cache_ttl_minutes", 10)),
     ), created
+
+
+def load_cache(ttl_minutes: int) -> list[dict] | None:
+    if not CACHE_PATH.exists():
+        return None
+    try:
+        data = json.loads(CACHE_PATH.read_text())
+        if time.time() - data["ts"] > ttl_minutes * 60:
+            return None
+        return data["items"]
+    except Exception:
+        return None
+
+
+def save_cache(items: list[dict]) -> None:
+    try:
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        CACHE_PATH.write_text(json.dumps({"ts": time.time(), "items": items}))
+    except Exception:
+        pass

--- a/grokfeed/main.py
+++ b/grokfeed/main.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import click
 
-from .config import load_config, CONFIG_PATH
-from .app import GrokFeedApp
-
 
 @click.command()
 def app() -> None:
     """Hacker News + Reddit terminal feed viewer."""
+    from .config import load_config, CONFIG_PATH
+    from .app import GrokFeedApp
+
     config, created = load_config()
     if created:
         click.echo(f"Config created: {CONFIG_PATH}\nEdit it to add/remove subreddits.")

--- a/grokfeed/main.py
+++ b/grokfeed/main.py
@@ -1,25 +1,17 @@
 from __future__ import annotations
 
-import typer
-from rich.console import Console
+import click
 
 from .config import load_config, CONFIG_PATH
 from .app import GrokFeedApp
 
-app = typer.Typer(help="Hacker News + Reddit terminal feed viewer.", add_completion=False)
-console = Console()
 
-
-@app.command()
-def run() -> None:
-    """Launch the grokfeed TUI."""
+@click.command()
+def app() -> None:
+    """Hacker News + Reddit terminal feed viewer."""
     config, created = load_config()
     if created:
-        console.print(
-            f"[bold green]Config created:[/] {CONFIG_PATH}\n"
-            "Edit it to add/remove subreddits.",
-            highlight=False,
-        )
+        click.echo(f"Config created: {CONFIG_PATH}\nEdit it to add/remove subreddits.")
     GrokFeedApp(config).run()
 
 

--- a/grokfeed/sources/comments.py
+++ b/grokfeed/sources/comments.py
@@ -6,6 +6,7 @@ import re as _re
 from dataclasses import dataclass
 
 import httpx
+import orjson
 
 USER_AGENT = "grokfeed:v0.1.0 (terminal feed reader)"
 HN_ITEM = "https://hacker-news.firebaseio.com/v0/item/{}.json"
@@ -36,7 +37,7 @@ async def _fetch_hn_comment(
         try:
             r = await client.get(HN_ITEM.format(cid), timeout=10)
             r.raise_for_status()
-            d = r.json()
+            d = orjson.loads(r.content)
             if not d or d.get("deleted") or d.get("dead") or d.get("type") != "comment":
                 return None
             raw = d.get("text", "")
@@ -55,7 +56,7 @@ async def fetch_hn_comments(story_id: int, limit: int = 30) -> list[Comment]:
     async with httpx.AsyncClient() as client:
         r = await client.get(HN_ITEM.format(story_id), timeout=10)
         r.raise_for_status()
-        d = r.json()
+        d = orjson.loads(r.content)
         kids = (d.get("kids") or [])[:limit]
         tasks = [_fetch_hn_comment(client, sem, kid) for kid in kids]
         results = await asyncio.gather(*tasks)
@@ -94,7 +95,7 @@ async def fetch_reddit_comments(subreddit: str, post_id: str) -> list[Comment]:
         try:
             r = await client.get(url, timeout=15)
             r.raise_for_status()
-            data = r.json()
+            data = orjson.loads(r.content)
         except Exception:
             return []
     # data is [post_listing, comments_listing]
@@ -113,7 +114,7 @@ async def fetch_lobsters_comments(short_id: str) -> list[Comment]:
         try:
             r = await client.get(url, timeout=15)
             r.raise_for_status()
-            data = r.json()
+            data = orjson.loads(r.content)
         except Exception:
             return []
     out: list[Comment] = []

--- a/grokfeed/sources/comments.py
+++ b/grokfeed/sources/comments.py
@@ -6,7 +6,6 @@ import re as _re
 from dataclasses import dataclass
 
 import httpx
-import orjson
 
 USER_AGENT = "grokfeed:v0.1.0 (terminal feed reader)"
 HN_ITEM = "https://hacker-news.firebaseio.com/v0/item/{}.json"
@@ -37,7 +36,7 @@ async def _fetch_hn_comment(
         try:
             r = await client.get(HN_ITEM.format(cid), timeout=10)
             r.raise_for_status()
-            d = orjson.loads(r.content)
+            d = r.json()
             if not d or d.get("deleted") or d.get("dead") or d.get("type") != "comment":
                 return None
             raw = d.get("text", "")
@@ -56,7 +55,7 @@ async def fetch_hn_comments(story_id: int, limit: int = 30) -> list[Comment]:
     async with httpx.AsyncClient() as client:
         r = await client.get(HN_ITEM.format(story_id), timeout=10)
         r.raise_for_status()
-        d = orjson.loads(r.content)
+        d = r.json()
         kids = (d.get("kids") or [])[:limit]
         tasks = [_fetch_hn_comment(client, sem, kid) for kid in kids]
         results = await asyncio.gather(*tasks)
@@ -95,7 +94,7 @@ async def fetch_reddit_comments(subreddit: str, post_id: str) -> list[Comment]:
         try:
             r = await client.get(url, timeout=15)
             r.raise_for_status()
-            data = orjson.loads(r.content)
+            data = r.json()
         except Exception:
             return []
     # data is [post_listing, comments_listing]
@@ -114,7 +113,7 @@ async def fetch_lobsters_comments(short_id: str) -> list[Comment]:
         try:
             r = await client.get(url, timeout=15)
             r.raise_for_status()
-            data = orjson.loads(r.content)
+            data = r.json()
         except Exception:
             return []
     out: list[Comment] = []

--- a/grokfeed/sources/comments.py
+++ b/grokfeed/sources/comments.py
@@ -51,17 +51,14 @@ async def _fetch_hn_comment(
 
 
 async def fetch_hn_comments(story_id: int, limit: int = 30) -> list[Comment]:
+    sem = asyncio.Semaphore(10)
     async with httpx.AsyncClient() as client:
         r = await client.get(HN_ITEM.format(story_id), timeout=10)
         r.raise_for_status()
         d = r.json()
         kids = (d.get("kids") or [])[:limit]
-
-    sem = asyncio.Semaphore(10)
-    async with httpx.AsyncClient() as client:
         tasks = [_fetch_hn_comment(client, sem, kid) for kid in kids]
         results = await asyncio.gather(*tasks)
-
     return [c for c in results if c is not None]
 
 

--- a/grokfeed/sources/hn.py
+++ b/grokfeed/sources/hn.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass
 
 import httpx
+import orjson
 
 HN_BASE = "https://hacker-news.firebaseio.com/v0"
 HN_ITEM = HN_BASE + "/item/{}.json"
@@ -35,7 +36,7 @@ async def _fetch_item(client: httpx.AsyncClient, item_id: int) -> Story | None:
     try:
         r = await client.get(HN_ITEM.format(item_id), timeout=10)
         r.raise_for_status()
-        d = r.json()
+        d = orjson.loads(r.content)
         if not d or d.get("type") != "story":
             return None
         raw_text = d.get("text", "")
@@ -59,7 +60,7 @@ async def fetch_hn_stories(
         sem = asyncio.Semaphore(10)
         r = await c.get(HN_TOP, timeout=10)
         r.raise_for_status()
-        ids = r.json()[:count]
+        ids = orjson.loads(r.content)[:count]
 
         async def _bounded(item_id: int) -> Story | None:
             async with sem:

--- a/grokfeed/sources/hn.py
+++ b/grokfeed/sources/hn.py
@@ -51,11 +51,24 @@ async def _fetch_item(client: httpx.AsyncClient, item_id: int) -> Story | None:
         return None
 
 
-async def fetch_hn_stories(count: int = 30) -> list[Story]:
-    async with httpx.AsyncClient() as client:
-        r = await client.get(HN_TOP, timeout=10)
+async def fetch_hn_stories(
+    count: int = 30,
+    client: httpx.AsyncClient | None = None,
+) -> list[Story]:
+    async def _run(c: httpx.AsyncClient) -> list[Story]:
+        sem = asyncio.Semaphore(10)
+        r = await c.get(HN_TOP, timeout=10)
         r.raise_for_status()
         ids = r.json()[:count]
-        tasks = [_fetch_item(client, i) for i in ids]
-        results = await asyncio.gather(*tasks)
-    return [s for s in results if s is not None]
+
+        async def _bounded(item_id: int) -> Story | None:
+            async with sem:
+                return await _fetch_item(c, item_id)
+
+        results = await asyncio.gather(*[_bounded(i) for i in ids])
+        return [s for s in results if s is not None]
+
+    if client is not None:
+        return await _run(client)
+    async with httpx.AsyncClient() as c:
+        return await _run(c)

--- a/grokfeed/sources/hn.py
+++ b/grokfeed/sources/hn.py
@@ -4,7 +4,6 @@ import asyncio
 from dataclasses import dataclass
 
 import httpx
-import orjson
 
 HN_BASE = "https://hacker-news.firebaseio.com/v0"
 HN_ITEM = HN_BASE + "/item/{}.json"
@@ -36,7 +35,7 @@ async def _fetch_item(client: httpx.AsyncClient, item_id: int) -> Story | None:
     try:
         r = await client.get(HN_ITEM.format(item_id), timeout=10)
         r.raise_for_status()
-        d = orjson.loads(r.content)
+        d = r.json()
         if not d or d.get("type") != "story":
             return None
         raw_text = d.get("text", "")
@@ -60,7 +59,7 @@ async def fetch_hn_stories(
         sem = asyncio.Semaphore(10)
         r = await c.get(HN_TOP, timeout=10)
         r.raise_for_status()
-        ids = orjson.loads(r.content)[:count]
+        ids = r.json()[:count]
 
         async def _bounded(item_id: int) -> Story | None:
             async with sem:

--- a/grokfeed/sources/lobsters.py
+++ b/grokfeed/sources/lobsters.py
@@ -5,6 +5,7 @@ import re as _re
 from dataclasses import dataclass, field
 
 import httpx
+import orjson
 
 
 def _strip_html(raw: str) -> str:
@@ -35,7 +36,7 @@ async def fetch_lobsters_posts(
         try:
             r = await c.get(LOBSTERS_URL, timeout=15, headers={"User-Agent": USER_AGENT})
             r.raise_for_status()
-            data = r.json()
+            data = orjson.loads(r.content)
         except Exception:
             return []
         posts: list[LobstersPost] = []

--- a/grokfeed/sources/lobsters.py
+++ b/grokfeed/sources/lobsters.py
@@ -5,7 +5,6 @@ import re as _re
 from dataclasses import dataclass, field
 
 import httpx
-import orjson
 
 
 def _strip_html(raw: str) -> str:
@@ -36,7 +35,7 @@ async def fetch_lobsters_posts(
         try:
             r = await c.get(LOBSTERS_URL, timeout=15, headers={"User-Agent": USER_AGENT})
             r.raise_for_status()
-            data = orjson.loads(r.content)
+            data = r.json()
         except Exception:
             return []
         posts: list[LobstersPost] = []

--- a/grokfeed/sources/lobsters.py
+++ b/grokfeed/sources/lobsters.py
@@ -27,26 +27,32 @@ class LobstersPost:
     source: str = "lobste.rs"
 
 
-async def fetch_lobsters_posts(count: int = 25) -> list[LobstersPost]:
-    headers = {"User-Agent": USER_AGENT}
-    async with httpx.AsyncClient(headers=headers) as client:
+async def fetch_lobsters_posts(
+    count: int = 25,
+    client: httpx.AsyncClient | None = None,
+) -> list[LobstersPost]:
+    async def _run(c: httpx.AsyncClient) -> list[LobstersPost]:
         try:
-            r = await client.get(LOBSTERS_URL, timeout=15)
+            r = await c.get(LOBSTERS_URL, timeout=15, headers={"User-Agent": USER_AGENT})
             r.raise_for_status()
             data = r.json()
         except Exception:
             return []
+        posts: list[LobstersPost] = []
+        for item in data[:count]:
+            raw_desc = item.get("description", "")
+            ext_url = item.get("url", "")
+            posts.append(LobstersPost(
+                id=item.get("short_id", ""),
+                title=item.get("title", "(no title)"),
+                url=ext_url or item.get("comments_url", ""),
+                score=item.get("score", 0),
+                comments=item.get("comment_count", 0),
+                body=_strip_html(raw_desc) if raw_desc else "",
+            ))
+        return posts
 
-    posts: list[LobstersPost] = []
-    for item in data[:count]:
-        raw_desc = item.get("description", "")
-        ext_url = item.get("url", "")
-        posts.append(LobstersPost(
-            id=item.get("short_id", ""),
-            title=item.get("title", "(no title)"),
-            url=ext_url or item.get("comments_url", ""),
-            score=item.get("score", 0),
-            comments=item.get("comment_count", 0),
-            body=_strip_html(raw_desc) if raw_desc else "",
-        ))
-    return posts
+    if client is not None:
+        return await _run(client)
+    async with httpx.AsyncClient() as c:
+        return await _run(c)

--- a/grokfeed/sources/reddit.py
+++ b/grokfeed/sources/reddit.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass
 
 import httpx
+import orjson
 
 USER_AGENT = "grokfeed:v0.1.0 (terminal feed reader)"
 REDDIT_HOT = "https://www.reddit.com/r/{subreddit}/hot.json?limit={limit}"
@@ -32,7 +33,7 @@ async def _fetch_subreddit(
         url = REDDIT_HOT.format(subreddit=subreddit, limit=count)
         r = await client.get(url, timeout=15, headers={"User-Agent": USER_AGENT})
         r.raise_for_status()
-        data = r.json()
+        data = orjson.loads(r.content)
         for child in data.get("data", {}).get("children", []):
             d = child.get("data", {})
             selftext = d.get("selftext", "")

--- a/grokfeed/sources/reddit.py
+++ b/grokfeed/sources/reddit.py
@@ -30,7 +30,7 @@ async def _fetch_subreddit(
     posts: list[RedditPost] = []
     try:
         url = REDDIT_HOT.format(subreddit=subreddit, limit=count)
-        r = await client.get(url, timeout=15)
+        r = await client.get(url, timeout=15, headers={"User-Agent": USER_AGENT})
         r.raise_for_status()
         data = r.json()
         for child in data.get("data", {}).get("children", []):
@@ -53,12 +53,22 @@ async def _fetch_subreddit(
     return posts
 
 
-async def fetch_reddit_posts(subreddits: list[str], count: int = 15) -> list[RedditPost]:
+async def fetch_reddit_posts(
+    subreddits: list[str],
+    count: int = 15,
+    client: httpx.AsyncClient | None = None,
+) -> list[RedditPost]:
     headers = {"User-Agent": USER_AGENT}
-    async with httpx.AsyncClient(headers=headers) as client:
-        tasks = [_fetch_subreddit(client, sub, count) for sub in subreddits]
+
+    async def _run(c: httpx.AsyncClient) -> list[RedditPost]:
+        tasks = [_fetch_subreddit(c, sub, count) for sub in subreddits]
         results = await asyncio.gather(*tasks)
-    posts: list[RedditPost] = []
-    for batch in results:
-        posts.extend(batch)
-    return posts
+        posts: list[RedditPost] = []
+        for batch in results:
+            posts.extend(batch)
+        return posts
+
+    if client is not None:
+        return await _run(client)
+    async with httpx.AsyncClient(headers=headers) as c:
+        return await _run(c)

--- a/grokfeed/sources/reddit.py
+++ b/grokfeed/sources/reddit.py
@@ -4,7 +4,6 @@ import asyncio
 from dataclasses import dataclass
 
 import httpx
-import orjson
 
 USER_AGENT = "grokfeed:v0.1.0 (terminal feed reader)"
 REDDIT_HOT = "https://www.reddit.com/r/{subreddit}/hot.json?limit={limit}"
@@ -33,7 +32,7 @@ async def _fetch_subreddit(
         url = REDDIT_HOT.format(subreddit=subreddit, limit=count)
         r = await client.get(url, timeout=15, headers={"User-Agent": USER_AGENT})
         r.raise_for_status()
-        data = orjson.loads(r.content)
+        data = r.json()
         for child in data.get("data", {}).get("children", []):
             d = child.get("data", {})
             selftext = d.get("selftext", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "textual>=0.47.0",
     "httpx[http2]>=0.27.0",
     "click>=8.0.0",
-    "orjson>=3.9.0",
     "tomli>=2.0.0; python_version < '3.11'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,9 @@ description = "Hacker News + Reddit terminal feed viewer"
 requires-python = ">=3.11"
 dependencies = [
     "textual>=0.47.0",
-    "httpx>=0.27.0",
+    "httpx[http2]>=0.27.0",
     "click>=8.0.0",
+    "orjson>=3.9.0",
     "tomli>=2.0.0; python_version < '3.11'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,7 @@ requires-python = ">=3.11"
 dependencies = [
     "textual>=0.47.0",
     "httpx>=0.27.0",
-    "typer>=0.12.0",
-    "rich>=13.0.0",
+    "click>=8.0.0",
     "tomli>=2.0.0; python_version < '3.11'",
 ]
 


### PR DESCRIPTION
  ## Summary

  - Replace `typer` with `click` — removes `shellingham` dependency, lighter install with no functional change (single no-arg command)
  - Drop `rich` from direct deps — already a `textual` transitive dep, redundant declaration
  - Add `httpx[http2]` — multiplexes repeated requests to the same host (HN Firebase) over a single connection
  - Share one `httpx.AsyncClient` across all three source fetchers at startup to reuse connections and skip redundant TLS handshakes
  - Add `asyncio.Semaphore(10)` to HN story fetches — was unbounded, now consistent with comment fetching
  - Fix `fetch_hn_comments` opening two `AsyncClient` contexts for one operation — now uses one
  - Add disk cache at `~/.grokfeed/cache.json` with configurable TTL (default 10 min via `cache_ttl_minutes` in `config.toml`) — cache hit skips all network and loads feed instantly on re-launch
  - Lazy-import `textual` and app internals inside the CLI handler so
    the interpreter is responsive before heavy modules load