### PR TITLE
fix: preserve active source filter on refresh

### DIFF
--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -160,7 +160,6 @@ class GrokFeedApp(App):
         self.push_screen(PostSplitModal(item, color))
 
     def action_refresh(self) -> None:
-        self._source_filter = ALL
         self.run_worker(self._load_all(), exclusive=True, name="fetch")
 
     def action_cycle_source(self) -> None:


### PR DESCRIPTION
Removes the unconditional reset of _source_filter to ALL in action_refresh. Filter now stays on the current source tab when the user presses r.

Closes #3