### PR TITLE
feat: add load-more pagination for HN and Reddit

### DIFF
--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -10,7 +10,7 @@ from textual.widgets import Footer, Header, LoadingIndicator, Label, ListView
 from textual.containers import Container
 
 from .config import Config, load_cache, save_cache
-from .sources.hn import fetch_hn_stories
+from .sources.hn import fetch_hn_stories, fetch_hn_top_ids, fetch_hn_stories_by_ids
 from .sources.reddit import fetch_reddit_posts
 from .sources.lobsters import fetch_lobsters_posts
 from .widgets.feed import FeedList
@@ -67,6 +67,7 @@ class GrokFeedApp(App):
         Binding("enter", "open_or_body", "Open", priority=True),
         Binding("f", "cycle_source", "Filter"),
         Binding("r", "refresh", "Refresh"),
+        Binding("m", "load_more", "More"),
         Binding("q", "quit", "Quit"),
     ]
 
@@ -80,6 +81,9 @@ class GrokFeedApp(App):
         self._source_filter: str = ALL
         self._sources: list[str] = []
         self._loading = False
+        self._hn_ids: list[int] = []
+        self._hn_offset: int = 0
+        self._reddit_after: dict[str, str] = {}
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -111,16 +115,18 @@ class GrokFeedApp(App):
         self._set_status("Fetching stories…")
         try:
             async with httpx.AsyncClient() as client:
-                hn_task = asyncio.create_task(
-                    fetch_hn_stories(self.config.hn_story_count, client)
-                )
+                self._hn_ids = await fetch_hn_top_ids(client)
+                hn_ids = self._hn_ids[:self.config.hn_story_count]
+                self._hn_offset = len(hn_ids)
+
+                hn_task = asyncio.create_task(fetch_hn_stories_by_ids(hn_ids, client))
                 reddit_task = asyncio.create_task(
                     fetch_reddit_posts(self.config.subreddits, self.config.reddit_post_count, client)
                 )
                 lobsters_task = asyncio.create_task(
                     fetch_lobsters_posts(self.config.lobsters_post_count, client)
                 )
-                hn_stories, reddit_posts, lobsters_posts = await asyncio.gather(
+                hn_stories, (reddit_posts, self._reddit_after), lobsters_posts = await asyncio.gather(
                     hn_task, reddit_task, lobsters_task
                 )
         except Exception as e:
@@ -172,6 +178,44 @@ class GrokFeedApp(App):
             return
         color = get_source_color(item["source"], 0)
         self.push_screen(PostSplitModal(item, color))
+
+    def action_load_more(self) -> None:
+        self.run_worker(self._fetch_more(), exclusive=True, name="fetch-more")
+
+    async def _fetch_more(self) -> None:
+        self._set_status("Loading more…")
+        try:
+            async with httpx.AsyncClient() as client:
+                hn_ids = self._hn_ids[self._hn_offset:self._hn_offset + self.config.hn_story_count]
+                hn_task = asyncio.create_task(fetch_hn_stories_by_ids(hn_ids, client))
+                reddit_task = asyncio.create_task(
+                    fetch_reddit_posts(
+                        self.config.subreddits,
+                        self.config.reddit_post_count,
+                        client,
+                        after=self._reddit_after,
+                    )
+                )
+                hn_stories, (reddit_posts, new_after) = await asyncio.gather(hn_task, reddit_task)
+        except Exception as e:
+            self._set_status(f"Error: {e}")
+            return
+
+        self._hn_offset += len(hn_ids)
+        self._reddit_after = new_after
+
+        existing_ids = {i["post_id"] for i in self._all_items}
+        new_items: list[dict] = []
+        for s in hn_stories:
+            if str(s.id) not in existing_ids:
+                new_items.append({"title": s.title, "source": "HN", "score": s.score, "comments": s.comments, "url": s.url, "body": s.body, "post_id": str(s.id)})
+        for p in reddit_posts:
+            if p.id not in existing_ids:
+                new_items.append({"title": p.title, "source": p.source, "score": p.score, "comments": p.comments, "url": p.url, "body": p.body, "post_id": p.id, "subreddit": p.subreddit})
+
+        self._all_items.extend(new_items)
+        self._sources = [ALL] + list(dict.fromkeys(i["source"] for i in self._all_items))
+        self._apply_filter()
 
     def action_refresh(self) -> None:
         self.run_worker(self._load_all(), exclusive=True, name="fetch")

--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -42,6 +42,7 @@ class GrokFeedApp(App):
     CSS = """
     Screen {
         background: $surface;
+        overflow-y: hidden;
     }
     #status-bar {
         height: 1;

--- a/grokfeed/sources/hn.py
+++ b/grokfeed/sources/hn.py
@@ -51,15 +51,18 @@ async def _fetch_item(client: httpx.AsyncClient, item_id: int) -> Story | None:
         return None
 
 
-async def fetch_hn_stories(
-    count: int = 30,
+async def fetch_hn_top_ids(client: httpx.AsyncClient) -> list[int]:
+    r = await client.get(HN_TOP, timeout=10)
+    r.raise_for_status()
+    return r.json()
+
+
+async def fetch_hn_stories_by_ids(
+    ids: list[int],
     client: httpx.AsyncClient | None = None,
 ) -> list[Story]:
     async def _run(c: httpx.AsyncClient) -> list[Story]:
         sem = asyncio.Semaphore(10)
-        r = await c.get(HN_TOP, timeout=10)
-        r.raise_for_status()
-        ids = r.json()[:count]
 
         async def _bounded(item_id: int) -> Story | None:
             async with sem:
@@ -67,6 +70,20 @@ async def fetch_hn_stories(
 
         results = await asyncio.gather(*[_bounded(i) for i in ids])
         return [s for s in results if s is not None]
+
+    if client is not None:
+        return await _run(client)
+    async with httpx.AsyncClient() as c:
+        return await _run(c)
+
+
+async def fetch_hn_stories(
+    count: int = 30,
+    client: httpx.AsyncClient | None = None,
+) -> list[Story]:
+    async def _run(c: httpx.AsyncClient) -> list[Story]:
+        ids = (await fetch_hn_top_ids(c))[:count]
+        return await fetch_hn_stories_by_ids(ids, c)
 
     if client is not None:
         return await _run(client)

--- a/grokfeed/sources/reddit.py
+++ b/grokfeed/sources/reddit.py
@@ -24,20 +24,29 @@ class RedditPost:
         return f"r/{self.subreddit}"
 
 
+REDDIT_HOT_AFTER = "https://www.reddit.com/r/{subreddit}/hot.json?limit={limit}&after={after}"
+
+
 async def _fetch_subreddit(
-    client: httpx.AsyncClient, subreddit: str, count: int
-) -> list[RedditPost]:
+    client: httpx.AsyncClient, subreddit: str, count: int, after: str = "",
+) -> tuple[list[RedditPost], str]:
     posts: list[RedditPost] = []
+    new_after = ""
     try:
-        url = REDDIT_HOT.format(subreddit=subreddit, limit=count)
+        url = (
+            REDDIT_HOT_AFTER.format(subreddit=subreddit, limit=count, after=after)
+            if after
+            else REDDIT_HOT.format(subreddit=subreddit, limit=count)
+        )
         r = await client.get(url, timeout=15, headers={"User-Agent": USER_AGENT})
         r.raise_for_status()
         data = r.json()
-        for child in data.get("data", {}).get("children", []):
+        listing = data.get("data", {})
+        new_after = listing.get("after") or ""
+        for child in listing.get("children", []):
             d = child.get("data", {})
             selftext = d.get("selftext", "")
             permalink = f"https://reddit.com{d.get('permalink', '')}"
-            # self-posts: url == permalink; fall back to permalink for open-in-browser
             post_url = d.get("url") or permalink
             posts.append(RedditPost(
                 id=d.get("id", ""),
@@ -50,25 +59,29 @@ async def _fetch_subreddit(
             ))
     except Exception:
         pass
-    return posts
+    return posts, new_after
 
 
 async def fetch_reddit_posts(
     subreddits: list[str],
     count: int = 15,
     client: httpx.AsyncClient | None = None,
-) -> list[RedditPost]:
-    headers = {"User-Agent": USER_AGENT}
+    after: dict[str, str] | None = None,
+) -> tuple[list[RedditPost], dict[str, str]]:
+    after = after or {}
 
-    async def _run(c: httpx.AsyncClient) -> list[RedditPost]:
-        tasks = [_fetch_subreddit(c, sub, count) for sub in subreddits]
+    async def _run(c: httpx.AsyncClient) -> tuple[list[RedditPost], dict[str, str]]:
+        tasks = [_fetch_subreddit(c, sub, count, after.get(sub, "")) for sub in subreddits]
         results = await asyncio.gather(*tasks)
         posts: list[RedditPost] = []
-        for batch in results:
+        new_after: dict[str, str] = {}
+        for sub, (batch, cursor) in zip(subreddits, results):
             posts.extend(batch)
-        return posts
+            if cursor:
+                new_after[sub] = cursor
+        return posts, new_after
 
     if client is not None:
         return await _run(client)
-    async with httpx.AsyncClient(headers=headers) as c:
+    async with httpx.AsyncClient() as c:
         return await _run(c)

--- a/grokfeed/widgets/feed.py
+++ b/grokfeed/widgets/feed.py
@@ -1,24 +1,15 @@
 from __future__ import annotations
 
-from textual.app import ComposeResult
-from textual.reactive import reactive
-from textual.scroll_view import ScrollView
-from textual.widget import Widget
-from textual.widgets import ListView, ListItem, Label
+from textual.widgets import ListView, ListItem
 
 from .story import StoryRow, source_color
 
 
-class FeedList(Widget):
+class FeedList(ListView):
     """Scrollable list of StoryRow widgets."""
 
     DEFAULT_CSS = """
     FeedList {
-        height: 1fr;
-        overflow-x: hidden;
-        overflow-y: hidden;
-    }
-    FeedList ListView {
         height: 1fr;
         background: $surface;
     }
@@ -37,15 +28,10 @@ class FeedList(Widget):
         self._items: list[dict] = []
         self._subreddit_color_map: dict[str, str] = {}
 
-    def compose(self) -> ComposeResult:
-        yield ListView()
-
     def load_items(self, items: list[dict]) -> None:
-        """items: list of dicts with keys: title, source, score, comments, url"""
         self._items = items
         self._build_color_map(items)
-        lv = self.query_one(ListView)
-        lv.clear()
+        self.clear()
         for item in items:
             color = self._color_for(item["source"])
             row = StoryRow(
@@ -56,9 +42,9 @@ class FeedList(Widget):
                 url=item["url"],
                 color=color,
             )
-            lv.append(ListItem(row))
+            self.append(ListItem(row))
         if items:
-            lv.index = 0
+            self.index = 0
 
     def _build_color_map(self, items: list[dict]) -> None:
         idx = 0
@@ -74,10 +60,8 @@ class FeedList(Widget):
         return self._subreddit_color_map.get(source, source_color(source, 0))
 
     def current_item(self) -> dict | None:
-        lv = self.query_one(ListView)
-        idx = lv.index
-        if idx is not None and 0 <= idx < len(self._items):
-            return self._items[idx]
+        if self.index is not None and 0 <= self.index < len(self._items):
+            return self._items[self.index]
         return None
 
     def current_url(self) -> str | None:
@@ -85,7 +69,7 @@ class FeedList(Widget):
         return item["url"] if item else None
 
     def action_cursor_down(self) -> None:
-        self.query_one(ListView).action_cursor_down()
+        super().action_cursor_down()
 
     def action_cursor_up(self) -> None:
-        self.query_one(ListView).action_cursor_up()
+        super().action_cursor_up()

--- a/grokfeed/widgets/feed.py
+++ b/grokfeed/widgets/feed.py
@@ -12,13 +12,11 @@ from .story import StoryRow, source_color
 class FeedList(Widget):
     """Scrollable list of StoryRow widgets."""
 
-    COMPONENT_CLASSES = set()
-    SCROLLABLE = False
-
     DEFAULT_CSS = """
     FeedList {
         height: 1fr;
-        overflow: hidden hidden;
+        overflow-x: hidden;
+        overflow-y: hidden;
     }
     FeedList ListView {
         height: 1fr;

--- a/grokfeed/widgets/feed.py
+++ b/grokfeed/widgets/feed.py
@@ -12,9 +12,13 @@ from .story import StoryRow, source_color
 class FeedList(Widget):
     """Scrollable list of StoryRow widgets."""
 
+    COMPONENT_CLASSES = set()
+    SCROLLABLE = False
+
     DEFAULT_CSS = """
     FeedList {
         height: 1fr;
+        overflow: hidden hidden;
     }
     FeedList ListView {
         height: 1fr;


### PR DESCRIPTION
  ## Summary

  - Press `m` to fetch the next page of HN and Reddit stories without clearing the current feed
  - Splits HN fetching into `fetch_hn_top_ids` + `fetch_hn_stories_by_ids` so the full top-stories list is fetched once and paginated with an offset
  - Reddit pagination uses the `after` cursor returned by the API, tracked per subreddit
  - Deduplicates by `post_id` before appending so refreshing or repeated `m` presses won't produce duplicates
  - Refactors `FeedList` from a wrapper `Widget` to a direct `ListView` subclass, removing a layer of indirection