### PR TITLE
chore: add release changelog categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: "What's New"
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Performance
+      labels:
+        - performance
+    - title: Maintenance
+      labels:
+        - chore


### PR DESCRIPTION
## Summary

- Adds `.github/release.yml` to group the auto-generated GitHub Release changelog by label
- Categories: What's New (enhancement), Bug Fixes (bug), Performance (performance), Maintenance (chore)
