### PR TITLE
feat: time-decay interleaving for cross-source feed ranking

### DIFF
--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import math
+import time as _time
 
 import httpx
 from textual.app import App, ComposeResult
@@ -19,11 +21,15 @@ from .widgets.story import source_color as get_source_color
 # Source filter sentinel
 ALL = "all"
 
+# half-life ~17 hours
+DECAY_LAMBDA = 0.04
+
 
 def _interleave_by_score(items: list[dict]) -> list[dict]:
-    """Sort items by score normalized within each source (0–1 scale)."""
+    """Sort items by score normalized within each source, decayed by age."""
     from collections import defaultdict
 
+    now = _time.time()
     groups: dict[str, list[dict]] = defaultdict(list)
     for item in items:
         groups[item["source"]].append(item)
@@ -32,7 +38,9 @@ def _interleave_by_score(items: list[dict]) -> list[dict]:
         lo, hi = min(scores), max(scores)
         span = hi - lo or 1
         for item in source_items:
-            item["_norm_score"] = (item["score"] - lo) / span
+            norm = (item["score"] - lo) / span
+            age_hours = max(0.0, now - item.get("created_at", now)) / 3600
+            item["_norm_score"] = norm * math.exp(-DECAY_LAMBDA * age_hours)
     return sorted(items, key=lambda i: i.get("_norm_score", 0), reverse=True)
 
 
@@ -150,6 +158,7 @@ class GrokFeedApp(App):
                     "url": s.url,
                     "body": s.body,
                     "post_id": str(s.id),
+                    "created_at": s.created_at,
                 }
             )
         for p in reddit_posts:
@@ -163,6 +172,7 @@ class GrokFeedApp(App):
                     "body": p.body,
                     "post_id": p.id,
                     "subreddit": p.subreddit,
+                    "created_at": p.created_at,
                 }
             )
         for lp in lobsters_posts:
@@ -175,6 +185,7 @@ class GrokFeedApp(App):
                     "url": lp.url,
                     "body": lp.body,
                     "post_id": lp.id,
+                    "created_at": lp.created_at,
                 }
             )
 
@@ -255,6 +266,7 @@ class GrokFeedApp(App):
                         "url": s.url,
                         "body": s.body,
                         "post_id": str(s.id),
+                        "created_at": s.created_at,
                     }
                 )
         for p in reddit_posts:
@@ -269,6 +281,7 @@ class GrokFeedApp(App):
                         "body": p.body,
                         "post_id": p.id,
                         "subreddit": p.subreddit,
+                        "created_at": p.created_at,
                     }
                 )
 

--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -39,7 +39,8 @@ def _interleave_by_score(items: list[dict]) -> list[dict]:
         span = hi - lo or 1
         for item in source_items:
             norm = (item["score"] - lo) / span
-            age_hours = max(0.0, now - item.get("created_at", now)) / 3600
+            created_at = item.get("created_at") or now
+            age_hours = max(0.0, now - created_at) / 3600
             item["_norm_score"] = norm * math.exp(-DECAY_LAMBDA * age_hours)
     return sorted(items, key=lambda i: i.get("_norm_score", 0), reverse=True)
 

--- a/grokfeed/sources/hn.py
+++ b/grokfeed/sources/hn.py
@@ -27,6 +27,7 @@ class Story:
     comments: int
     body: str = ""  # present for Ask HN / Tell HN posts
     source: str = "HN"
+    created_at: int = 0
 
 
 async def _fetch_item(client: httpx.AsyncClient, item_id: int) -> Story | None:
@@ -44,6 +45,7 @@ async def _fetch_item(client: httpx.AsyncClient, item_id: int) -> Story | None:
             score=d.get("score", 0),
             comments=d.get("descendants", 0),
             body=_strip_html(raw_text) if raw_text else "",
+            created_at=int(d.get("time", 0)),
         )
     except Exception:
         return None

--- a/grokfeed/sources/lobsters.py
+++ b/grokfeed/sources/lobsters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import html as _html
 import re as _re
 from dataclasses import dataclass
+from datetime import datetime
 
 import httpx
 
@@ -26,6 +27,7 @@ class LobstersPost:
     comments: int
     body: str = ""  # description for discussion posts
     source: str = "lobste.rs"
+    created_at: int = 0
 
 
 async def fetch_lobsters_posts(
@@ -43,6 +45,11 @@ async def fetch_lobsters_posts(
         for item in data[:count]:
             raw_desc = item.get("description", "")
             ext_url = item.get("url", "")
+            ts = item.get("created_at", "")
+            try:
+                created_at = int(datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp())
+            except (ValueError, AttributeError):
+                created_at = 0
             posts.append(
                 LobstersPost(
                     id=item.get("short_id", ""),
@@ -51,6 +58,7 @@ async def fetch_lobsters_posts(
                     score=item.get("score", 0),
                     comments=item.get("comment_count", 0),
                     body=_strip_html(raw_desc) if raw_desc else "",
+                    created_at=created_at,
                 )
             )
         return posts

--- a/grokfeed/sources/reddit.py
+++ b/grokfeed/sources/reddit.py
@@ -18,6 +18,7 @@ class RedditPost:
     comments: int
     subreddit: str
     body: str = ""  # selftext for text posts; empty for link posts
+    created_at: int = 0
 
     @property
     def source(self) -> str:
@@ -60,6 +61,7 @@ async def _fetch_subreddit(
                     comments=d.get("num_comments", 0),
                     subreddit=subreddit,
                     body=selftext if selftext not in ("", "[deleted]", "[removed]") else "",
+                    created_at=int(d.get("created_utc", 0)),
                 )
             )
     except Exception:

--- a/tests/test_interleave.py
+++ b/tests/test_interleave.py
@@ -1,8 +1,17 @@
+import time
+
 from grokfeed.app import _interleave_by_score
 
 
-def _item(source: str, score: int) -> dict:
-    return {"source": source, "score": score, "title": "", "url": "", "comments": 0}
+def _item(source: str, score: int, created_at: int = 0) -> dict:
+    return {
+        "source": source,
+        "score": score,
+        "title": "",
+        "url": "",
+        "comments": 0,
+        "created_at": created_at,
+    }
 
 
 def test_empty():
@@ -23,11 +32,12 @@ def test_sorted_descending_within_source():
 
 
 def test_normalizes_per_source_top_items_interleaved():
+    now = int(time.time())
     items = [
-        _item("HN", 1000),
-        _item("HN", 500),
-        _item("r/python", 10),
-        _item("r/python", 5),
+        _item("HN", 1000, created_at=now),
+        _item("HN", 500, created_at=now),
+        _item("r/python", 10, created_at=now),
+        _item("r/python", 5, created_at=now),
     ]
     result = _interleave_by_score(items)
     # Top item from each source gets norm_score=1.0 and should appear first
@@ -47,3 +57,39 @@ def test_multiple_sources_all_represented():
     result = _interleave_by_score(items)
     result_sources = {r["source"] for r in result}
     assert result_sources == set(sources)
+
+
+def test_time_decay_reorders_within_source():
+    now = int(time.time())
+    # 3 items same source. Without decay: high_old > mid_new > low_new.
+    # With decay (λ=0.04, half-life~17h): high_old (100h) decays to ~0.02, mid_new (1h) ~0.48.
+    high_old = _item("HN", 100, created_at=now - 100 * 3600)
+    mid_new = _item("HN", 80, created_at=now - 1 * 3600)
+    low_new = _item("HN", 60, created_at=now)
+    result = _interleave_by_score([high_old, mid_new, low_new])
+    assert result[0]["score"] == 80  # mid_new wins due to freshness despite lower score
+
+
+def test_time_decay_cross_source_newer_source_wins():
+    now = int(time.time())
+    # Each source has 2 items so the top item gets norm=1.0.
+    # HN top is very old (72h): _score ≈ exp(-2.88) ≈ 0.056
+    # r/python top is very new (1h): _score ≈ exp(-0.04) ≈ 0.96
+    items = [
+        _item("HN", 1000, created_at=now - 72 * 3600),
+        _item("HN", 500, created_at=now - 72 * 3600),
+        _item("r/python", 20, created_at=now - 1 * 3600),
+        _item("r/python", 10, created_at=now - 1 * 3600),
+    ]
+    result = _interleave_by_score(items)
+    # r/python's top item should outrank HN's top item due to freshness
+    assert result[0]["source"] == "r/python"
+
+
+def test_missing_created_at_no_decay_penalty():
+    # Items without created_at key use age=0 (no decay penalty)
+    item_no_ts = {"source": "HN", "score": 100, "title": "", "url": "", "comments": 0}
+    item_with_ts = _item("HN", 100, created_at=int(time.time()))
+    result = _interleave_by_score([item_no_ts, item_with_ts])
+    # Both have same score within same source → span=0 → norm=0 → _norm_score=0
+    assert all(r["_norm_score"] == 0.0 for r in result)

--- a/tests/test_interleave.py
+++ b/tests/test_interleave.py
@@ -87,9 +87,14 @@ def test_time_decay_cross_source_newer_source_wins():
 
 
 def test_missing_created_at_no_decay_penalty():
-    # Items without created_at key use age=0 (no decay penalty)
+    # item_no_ts has no created_at key → treated as age=0 → no decay penalty
+    # item_with_ts has lower score but a current timestamp → also age≈0
+    # With different scores span>0, so norm is computed and decay is exercised.
+    # The higher-scoring item_no_ts should have _norm_score >= item_with_ts.
+    now = int(time.time())
     item_no_ts = {"source": "HN", "score": 100, "title": "", "url": "", "comments": 0}
-    item_with_ts = _item("HN", 100, created_at=int(time.time()))
+    item_with_ts = _item("HN", 50, created_at=now)
     result = _interleave_by_score([item_no_ts, item_with_ts])
-    # Both have same score within same source → span=0 → norm=0 → _norm_score=0
-    assert all(r["_norm_score"] == 0.0 for r in result)
+    no_ts_result = next(r for r in result if r["score"] == 100)
+    with_ts_result = next(r for r in result if r["score"] == 50)
+    assert no_ts_result["_norm_score"] >= with_ts_result["_norm_score"]

--- a/tests/test_sources_hn.py
+++ b/tests/test_sources_hn.py
@@ -45,6 +45,7 @@ async def test_fetch_hn_stories_by_ids_link_post(httpx_mock: HTTPXMock):
             "score": 100,
             "descendants": 42,
             "text": "",
+            "time": 1700000000,
         },
     )
     async with httpx.AsyncClient() as client:
@@ -56,6 +57,7 @@ async def test_fetch_hn_stories_by_ids_link_post(httpx_mock: HTTPXMock):
     assert s.comments == 42
     assert s.url == "https://example.com"
     assert s.body == ""
+    assert s.created_at == 1700000000
 
 
 @pytest.mark.asyncio

--- a/tests/test_sources_lobsters.py
+++ b/tests/test_sources_lobsters.py
@@ -12,6 +12,7 @@ def _item(
     score: int = 10,
     comment_count: int = 5,
     description: str = "",
+    created_at: str = "2023-11-14T22:13:20.000Z",
 ) -> dict:
     return {
         "short_id": short_id,
@@ -21,6 +22,7 @@ def _item(
         "comment_count": comment_count,
         "description": description,
         "comments_url": f"https://lobste.rs/s/{short_id}",
+        "created_at": created_at,
     }
 
 
@@ -38,6 +40,7 @@ async def test_fetch_lobsters_posts_basic(httpx_mock: HTTPXMock):
     assert p.comments == 8
     assert p.source == "lobste.rs"
     assert p.url == "https://example.com"
+    assert p.created_at == 1700000000  # 2023-11-14T22:13:20Z
 
 
 @pytest.mark.asyncio

--- a/tests/test_sources_reddit.py
+++ b/tests/test_sources_reddit.py
@@ -16,6 +16,7 @@ def _child(
     subreddit: str = "python",
     is_self: bool = False,
     selftext: str = "",
+    created_utc: float = 1700000000.0,
 ) -> dict:
     return {
         "data": {
@@ -28,6 +29,7 @@ def _child(
             "permalink": f"/r/{subreddit}/comments/{post_id}/test/",
             "is_self": is_self,
             "selftext": selftext,
+            "created_utc": created_utc,
         }
     }
 
@@ -45,6 +47,7 @@ async def test_fetch_reddit_posts_link_post(httpx_mock: HTTPXMock):
     assert p.score == 500
     assert p.source == "r/python"
     assert p.url == "https://example.com"
+    assert p.created_at == 1700000000
     assert after == {"python": "t3_next"}
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -155,7 +155,7 @@ toml = [
 
 [[package]]
 name = "grokfeed"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Apply exponential decay (λ=0.04, half-life ~17h) to normalized per-source scores so that fresh stories rise above stale high-scorers. Add created_at timestamp to all source dataclasses (HN unix time, Reddit created_utc, lobste.rs ISO 8601). Update tests to cover decay reordering and timestamp propagation.

Closes #11 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced feed ranking algorithm to prioritize fresher content using time-decay scoring.

* **Tests**
  * Expanded test coverage for time-sensitive ranking behavior and cross-source ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->