### PR TITLE
feat: show 'press o to open in browser' prompt in link post panel

### DIFF
--- a/grokfeed/widgets/post_split_modal.py
+++ b/grokfeed/widgets/post_split_modal.py
@@ -120,7 +120,9 @@ class PostSplitModal(ModalScreen):
                         if body:
                             yield Markdown(body)
                         elif url:
-                            yield Label(f"[dim]Link post[/]\n\n{url}")
+                            yield Label(
+                                f"{url}\n\n[dim]Press [bold]o[/] to open in browser[/]"
+                            )
                         else:
                             yield Label("[dim]No content.[/]")
                 with Vertical(id="comments-panel"):

--- a/grokfeed/widgets/post_split_modal.py
+++ b/grokfeed/widgets/post_split_modal.py
@@ -120,9 +120,7 @@ class PostSplitModal(ModalScreen):
                         if body:
                             yield Markdown(body)
                         elif url:
-                            yield Label(
-                                f"{url}\n\n[dim]Press [bold]o[/] to open in browser[/]"
-                            )
+                            yield Label(f"{url}\n\n[dim]Press [bold]o[/] to open in browser[/]")
                         else:
                             yield Label("[dim]No content.[/]")
                 with Vertical(id="comments-panel"):


### PR DESCRIPTION
  - Link posts showed `Link post` label + URL but gave no hint that `o` opens the URL in a browser
  - The `o` binding existed and appeared in the bottom hint bar, but was easy to miss when focus was on the content area
  - Replace the dim label with the URL itself followed by `Press o to open in browser` directly in the post panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved display for link-only posts: URLs now render on two lines with a clear on-screen hint ("Press o to open in browser") to make it easier to view and open links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->