### PR TITLE
feat: mark seen posts with dimmed title, persist to seen.json

### DIFF
--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -9,6 +9,7 @@ from textual.containers import Container
 from textual.widgets import Footer, Header, Label, LoadingIndicator
 
 from .config import Config, load_cache, save_cache
+from .seen import load_seen, mark_seen
 from .sources.hn import fetch_hn_stories_by_ids, fetch_hn_top_ids
 from .sources.lobsters import fetch_lobsters_posts
 from .sources.reddit import fetch_reddit_posts
@@ -85,6 +86,7 @@ class GrokFeedApp(App):
         self._hn_ids: list[int] = []
         self._hn_offset: int = 0
         self._reddit_after: dict[str, str] = {}
+        self._seen: set[str] = load_seen()
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -194,7 +196,7 @@ class GrokFeedApp(App):
         else:
             visible = [i for i in self._all_items if i["source"] == self._source_filter]
             label = self._source_filter
-        feed.load_items(visible)
+        feed.load_items(visible, seen_ids=self._seen)
         suffix = " (cached)" if from_cache else ""
         self._set_status(f"{len(visible)} stories — {label}{suffix}")
 
@@ -212,6 +214,11 @@ class GrokFeedApp(App):
         item = feed.current_item()
         if not item:
             return
+        post_id = item.get("post_id", "")
+        if post_id:
+            self._seen.add(post_id)
+            mark_seen(post_id)
+            feed.mark_current_seen()
         color = get_source_color(item["source"], 0)
         self.push_screen(PostSplitModal(item, color))
 

--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -219,8 +219,9 @@ class GrokFeedApp(App):
             return
         post_id = item.get("post_id", "")
         if post_id:
-            self._seen.add(post_id)
-            mark_seen(post_id)
+            seen_key = f"{item.get('source', 'unknown')}:{post_id}"
+            self._seen.add(seen_key)
+            mark_seen(seen_key)
             feed.mark_current_seen()
         color = get_source_color(item["source"], 0)
         self.push_screen(PostSplitModal(item, color))

--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -100,6 +100,7 @@ class GrokFeedApp(App):
         self.run_worker(self._load_all(), exclusive=True, name="fetch")
 
     async def _load_all(self) -> None:
+        """Fetch all sources concurrently; serve from cache if still fresh."""
         loading = self.query_one("#loading")
         feed = self.query_one(FeedList)
         loading.display = True
@@ -189,6 +190,7 @@ class GrokFeedApp(App):
         feed.display = True
 
     def _apply_filter(self, from_cache: bool = False) -> None:
+        """Re-render the feed list for the active source filter."""
         feed = self.query_one(FeedList)
         if self._source_filter == ALL:
             visible = _interleave_by_score(self._all_items)
@@ -210,6 +212,7 @@ class GrokFeedApp(App):
         self.query_one(FeedList).action_cursor_up()
 
     def action_open_or_body(self) -> None:
+        """Open the split view for the highlighted story and mark it seen."""
         feed = self.query_one(FeedList)
         item = feed.current_item()
         if not item:
@@ -226,6 +229,7 @@ class GrokFeedApp(App):
         self.run_worker(self._fetch_more(), exclusive=True, name="fetch-more")
 
     async def _fetch_more(self) -> None:
+        """Fetch the next page of HN and Reddit items, skipping duplicates."""
         self._set_status("Loading more…")
         try:
             async with httpx.AsyncClient() as client:
@@ -287,6 +291,7 @@ class GrokFeedApp(App):
         self.run_worker(self._load_all(), exclusive=True, name="fetch")
 
     def action_cycle_source(self) -> None:
+        """Step through the source filter cycle (All → HN → subreddits → lobste.rs → …)."""
         if not self._sources:
             return
         try:

--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -221,7 +221,8 @@ class GrokFeedApp(App):
         if post_id:
             seen_key = f"{item.get('source', 'unknown')}:{post_id}"
             self._seen.add(seen_key)
-            mark_seen(seen_key)
+            if not mark_seen(seen_key):
+                self._set_status("Warning: could not write to seen.json — read state not persisted")
             feed.mark_current_seen()
         color = get_source_color(item["source"], 0)
         self.push_screen(PostSplitModal(item, color))

--- a/grokfeed/config.py
+++ b/grokfeed/config.py
@@ -25,6 +25,8 @@ cache_ttl_minutes = 10
 
 @dataclass
 class Config:
+    """Runtime settings loaded from ~/.grokfeed/config.toml."""
+
     subreddits: list[str] = field(
         default_factory=lambda: ["programming", "python", "machinelearning"]
     )
@@ -53,6 +55,7 @@ def load_config() -> tuple[Config, bool]:
 
 
 def load_cache(ttl_minutes: int) -> list[dict] | None:
+    """Return cached feed items if still within TTL, else None."""
     if not CACHE_PATH.exists():
         return None
     try:
@@ -65,6 +68,7 @@ def load_cache(ttl_minutes: int) -> list[dict] | None:
 
 
 def save_cache(items: list[dict]) -> None:
+    """Write feed items to disk with a current timestamp."""
     try:
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
         CACHE_PATH.write_text(json.dumps({"ts": time.time(), "items": items}))

--- a/grokfeed/seen.py
+++ b/grokfeed/seen.py
@@ -10,6 +10,7 @@ SEEN_TTL_SECONDS = 86_400  # 1 day
 
 
 def load_seen() -> set[str]:
+    """Return post IDs opened within the last 24 hours."""
     if not SEEN_PATH.exists():
         return set()
     try:
@@ -21,6 +22,7 @@ def load_seen() -> set[str]:
 
 
 def mark_seen(post_id: str) -> None:
+    """Record post_id as seen, pruning entries older than the TTL."""
     try:
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
         data: dict[str, float] = {}

--- a/grokfeed/seen.py
+++ b/grokfeed/seen.py
@@ -9,30 +9,42 @@ SEEN_PATH = CONFIG_DIR / "seen.json"
 SEEN_TTL_SECONDS = 86_400  # 1 day
 
 
+def _valid_ts(ts: object) -> float | None:
+    """Return ts as float if numeric, else None."""
+    try:
+        return float(ts)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_raw() -> dict[str, float]:
+    """Read seen.json, skipping entries with invalid timestamps."""
+    try:
+        raw = json.loads(SEEN_PATH.read_bytes())
+    except Exception:
+        return {}
+    result: dict[str, float] = {}
+    for pid, ts in raw.items():
+        v = _valid_ts(ts)
+        if v is not None:
+            result[pid] = v
+    return result
+
+
 def load_seen() -> set[str]:
     """Return post IDs opened within the last 24 hours."""
     if not SEEN_PATH.exists():
         return set()
-    try:
-        data: dict[str, float] = json.loads(SEEN_PATH.read_bytes())
-        cutoff = time.time() - SEEN_TTL_SECONDS
-        return {pid for pid, ts in data.items() if ts >= cutoff}
-    except Exception:
-        return set()
+    cutoff = time.time() - SEEN_TTL_SECONDS
+    return {pid for pid, ts in _load_raw().items() if ts >= cutoff}
 
 
 def mark_seen(post_id: str) -> bool:
     """Record post_id as seen, pruning entries older than the TTL. Returns False on write failure."""
     try:
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-        data: dict[str, float] = {}
-        if SEEN_PATH.exists():
-            try:
-                data = json.loads(SEEN_PATH.read_bytes())
-            except Exception:
-                pass
         cutoff = time.time() - SEEN_TTL_SECONDS
-        data = {pid: ts for pid, ts in data.items() if ts >= cutoff}
+        data = {pid: ts for pid, ts in _load_raw().items() if ts >= cutoff}
         data[post_id] = time.time()
         SEEN_PATH.write_text(json.dumps(data))
         return True

--- a/grokfeed/seen.py
+++ b/grokfeed/seen.py
@@ -21,8 +21,8 @@ def load_seen() -> set[str]:
         return set()
 
 
-def mark_seen(post_id: str) -> None:
-    """Record post_id as seen, pruning entries older than the TTL."""
+def mark_seen(post_id: str) -> bool:
+    """Record post_id as seen, pruning entries older than the TTL. Returns False on write failure."""
     try:
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
         data: dict[str, float] = {}
@@ -35,5 +35,6 @@ def mark_seen(post_id: str) -> None:
         data = {pid: ts for pid, ts in data.items() if ts >= cutoff}
         data[post_id] = time.time()
         SEEN_PATH.write_text(json.dumps(data))
+        return True
     except Exception:
-        pass
+        return False

--- a/grokfeed/seen.py
+++ b/grokfeed/seen.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import time
+
+from .config import CONFIG_DIR
+
+SEEN_PATH = CONFIG_DIR / "seen.json"
+SEEN_TTL_SECONDS = 86_400  # 1 day
+
+
+def load_seen() -> set[str]:
+    if not SEEN_PATH.exists():
+        return set()
+    try:
+        data: dict[str, float] = json.loads(SEEN_PATH.read_bytes())
+        cutoff = time.time() - SEEN_TTL_SECONDS
+        return {pid for pid, ts in data.items() if ts >= cutoff}
+    except Exception:
+        return set()
+
+
+def mark_seen(post_id: str) -> None:
+    try:
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        data: dict[str, float] = {}
+        if SEEN_PATH.exists():
+            try:
+                data = json.loads(SEEN_PATH.read_bytes())
+            except Exception:
+                pass
+        cutoff = time.time() - SEEN_TTL_SECONDS
+        data = {pid: ts for pid, ts in data.items() if ts >= cutoff}
+        data[post_id] = time.time()
+        SEEN_PATH.write_text(json.dumps(data))
+    except Exception:
+        pass

--- a/grokfeed/seen.py
+++ b/grokfeed/seen.py
@@ -23,6 +23,8 @@ def _load_raw() -> dict[str, float]:
         raw = json.loads(SEEN_PATH.read_bytes())
     except Exception:
         return {}
+    if not isinstance(raw, dict):
+        return {}
     result: dict[str, float] = {}
     for pid, ts in raw.items():
         v = _valid_ts(ts)

--- a/grokfeed/sources/comments.py
+++ b/grokfeed/sources/comments.py
@@ -15,6 +15,8 @@ LOBSTERS_POST = "https://lobste.rs/s/{short_id}.json"
 
 @dataclass
 class Comment:
+    """A single comment with author, score, plain-text body, and nesting depth."""
+
     author: str
     score: int
     body: str
@@ -52,6 +54,7 @@ async def _fetch_hn_comment(
 
 
 async def fetch_hn_comments(story_id: int, limit: int = 30) -> list[Comment]:
+    """Fetch top-level comments for a HN story."""
     sem = asyncio.Semaphore(10)
     async with httpx.AsyncClient() as client:
         r = await client.get(HN_ITEM.format(story_id), timeout=10)
@@ -92,6 +95,7 @@ def _flatten_reddit(children: list, depth: int = 0, max_depth: int = 2) -> list[
 
 
 async def fetch_reddit_comments(subreddit: str, post_id: str) -> list[Comment]:
+    """Fetch and flatten threaded comments for a Reddit post (depth ≤ 3)."""
     headers = {"User-Agent": USER_AGENT}
     url = REDDIT_COMMENTS.format(subreddit=subreddit, post_id=post_id)
     async with httpx.AsyncClient(headers=headers) as client:
@@ -112,6 +116,7 @@ async def fetch_reddit_comments(subreddit: str, post_id: str) -> list[Comment]:
 
 
 async def fetch_lobsters_comments(short_id: str) -> list[Comment]:
+    """Fetch comments for a lobste.rs post."""
     headers = {"User-Agent": USER_AGENT}
     url = LOBSTERS_POST.format(short_id=short_id)
     async with httpx.AsyncClient(headers=headers) as client:
@@ -144,6 +149,7 @@ async def fetch_lobsters_comments(short_id: str) -> list[Comment]:
 
 
 async def fetch_comments(item: dict) -> list[Comment]:
+    """Dispatch to the correct comment fetcher based on item source."""
     source = item.get("source", "")
     if source == "HN":
         return await fetch_hn_comments(int(item["post_id"]))

--- a/grokfeed/sources/hn.py
+++ b/grokfeed/sources/hn.py
@@ -20,6 +20,8 @@ def _strip_html(raw: str) -> str:
 
 @dataclass
 class Story:
+    """A Hacker News story."""
+
     id: int
     title: str
     url: str
@@ -50,6 +52,7 @@ async def _fetch_item(client: httpx.AsyncClient, item_id: int) -> Story | None:
 
 
 async def fetch_hn_top_ids(client: httpx.AsyncClient) -> list[int]:
+    """Return the current ranked list of top story IDs from HN."""
     r = await client.get(HN_TOP, timeout=10)
     r.raise_for_status()
     return r.json()
@@ -59,6 +62,8 @@ async def fetch_hn_stories_by_ids(
     ids: list[int],
     client: httpx.AsyncClient | None = None,
 ) -> list[Story]:
+    """Fetch Story objects for the given IDs with up to 10 concurrent requests."""
+
     async def _run(c: httpx.AsyncClient) -> list[Story]:
         sem = asyncio.Semaphore(10)
 
@@ -79,6 +84,8 @@ async def fetch_hn_stories(
     count: int = 30,
     client: httpx.AsyncClient | None = None,
 ) -> list[Story]:
+    """Fetch the top N stories from Hacker News."""
+
     async def _run(c: httpx.AsyncClient) -> list[Story]:
         ids = (await fetch_hn_top_ids(c))[:count]
         return await fetch_hn_stories_by_ids(ids, c)

--- a/grokfeed/sources/lobsters.py
+++ b/grokfeed/sources/lobsters.py
@@ -19,6 +19,8 @@ USER_AGENT = "grokfeed:v0.1.0 (terminal feed reader)"
 
 @dataclass
 class LobstersPost:
+    """A lobste.rs story from the hottest listing."""
+
     id: str
     title: str
     url: str
@@ -32,6 +34,8 @@ async def fetch_lobsters_posts(
     count: int = 25,
     client: httpx.AsyncClient | None = None,
 ) -> list[LobstersPost]:
+    """Fetch the top N hottest posts from lobste.rs."""
+
     async def _run(c: httpx.AsyncClient) -> list[LobstersPost]:
         try:
             r = await c.get(LOBSTERS_URL, timeout=15, headers={"User-Agent": USER_AGENT})

--- a/grokfeed/sources/reddit.py
+++ b/grokfeed/sources/reddit.py
@@ -11,6 +11,8 @@ REDDIT_HOT = "https://www.reddit.com/r/{subreddit}/hot.json?limit={limit}"
 
 @dataclass
 class RedditPost:
+    """A Reddit post from a subreddit hot listing."""
+
     id: str
     title: str
     url: str
@@ -73,6 +75,7 @@ async def fetch_reddit_posts(
     client: httpx.AsyncClient | None = None,
     after: dict[str, str] | None = None,
 ) -> tuple[list[RedditPost], dict[str, str]]:
+    """Fetch hot posts from multiple subreddits concurrently."""
     after = after or {}
 
     async def _run(c: httpx.AsyncClient) -> tuple[list[RedditPost], dict[str, str]]:

--- a/grokfeed/widgets/comments_modal.py
+++ b/grokfeed/widgets/comments_modal.py
@@ -12,6 +12,8 @@ INDENT = "  "
 
 
 class CommentWidget(Static):
+    """Renders an indented comment with author header and body."""
+
     DEFAULT_CSS = """
     CommentWidget {
         padding: 0 1;
@@ -36,6 +38,8 @@ class CommentWidget(Static):
 
 
 class CommentsModal(ModalScreen):
+    """Full-screen comment thread for a single post."""
+
     BINDINGS = [
         Binding("q", "dismiss", "Close"),
         Binding("escape", "dismiss", "Close", show=False),
@@ -97,6 +101,7 @@ class CommentsModal(ModalScreen):
         self.run_worker(self._load_comments(), exclusive=True)
 
     async def _load_comments(self) -> None:
+        """Fetch comments asynchronously and mount them into the scroll pane."""
         from ..sources.comments import fetch_comments
 
         loading = self.query_one("#loading-comments", Label)

--- a/grokfeed/widgets/content_modal.py
+++ b/grokfeed/widgets/content_modal.py
@@ -66,11 +66,13 @@ class ContentModal(ModalScreen):
             yield Label("q close  •  c comments  •  o open URL  •  j/k scroll", id="modal-hint")
 
     def action_open_comments(self) -> None:
+        """Push the comments modal onto the screen stack."""
         from .comments_modal import CommentsModal
 
         self.app.push_screen(CommentsModal(self._item, self._source_color))
 
     def action_open_url(self) -> None:
+        """Open the story URL in the system browser."""
         url = self._item.get("url")
         if url:
             self.app.open_url(url)

--- a/grokfeed/widgets/feed.py
+++ b/grokfeed/widgets/feed.py
@@ -28,10 +28,11 @@ class FeedList(ListView):
         self._items: list[dict] = []
         self._subreddit_color_map: dict[str, str] = {}
 
-    def load_items(self, items: list[dict]) -> None:
+    def load_items(self, items: list[dict], seen_ids: set[str] | None = None) -> None:
         self._items = items
         self._build_color_map(items)
         self.clear()
+        seen_ids = seen_ids or set()
         for item in items:
             color = self._color_for(item["source"])
             row = StoryRow(
@@ -41,10 +42,18 @@ class FeedList(ListView):
                 comments=item["comments"],
                 url=item["url"],
                 color=color,
+                seen=item.get("post_id", "") in seen_ids,
             )
             self.append(ListItem(row))
         if items:
             self.index = 0
+
+    def mark_current_seen(self) -> None:
+        if self.index is None:
+            return
+        rows = list(self.query(StoryRow))
+        if 0 <= self.index < len(rows):
+            rows[self.index].seen = True
 
     def _build_color_map(self, items: list[dict]) -> None:
         idx = 0

--- a/grokfeed/widgets/feed.py
+++ b/grokfeed/widgets/feed.py
@@ -29,6 +29,7 @@ class FeedList(ListView):
         self._subreddit_color_map: dict[str, str] = {}
 
     def load_items(self, items: list[dict], seen_ids: set[str] | None = None) -> None:
+        """Rebuild the list from items, dimming posts whose IDs are in seen_ids."""
         self._items = items
         self._build_color_map(items)
         self.clear()
@@ -49,6 +50,7 @@ class FeedList(ListView):
             self.index = 0
 
     def mark_current_seen(self) -> None:
+        """Dim the highlighted row in place without rebuilding the list."""
         if self.index is None:
             return
         rows = list(self.query(StoryRow))
@@ -56,6 +58,7 @@ class FeedList(ListView):
             rows[self.index].seen = True
 
     def _build_color_map(self, items: list[dict]) -> None:
+        """Assign a stable palette color to each subreddit on first encounter."""
         idx = 0
         for item in items:
             src = item["source"]
@@ -64,16 +67,19 @@ class FeedList(ListView):
                 idx += 1
 
     def _color_for(self, source: str) -> str:
+        """Return the pre-assigned display color for a source."""
         if source == "HN":
             return source_color("HN", 0)
         return self._subreddit_color_map.get(source, source_color(source, 0))
 
     def current_item(self) -> dict | None:
+        """Return the item dict for the highlighted row, or None."""
         if self.index is not None and 0 <= self.index < len(self._items):
             return self._items[self.index]
         return None
 
     def current_url(self) -> str | None:
+        """Return the URL of the highlighted item, or None."""
         item = self.current_item()
         return item["url"] if item else None
 

--- a/grokfeed/widgets/feed.py
+++ b/grokfeed/widgets/feed.py
@@ -43,7 +43,7 @@ class FeedList(ListView):
                 comments=item["comments"],
                 url=item["url"],
                 color=color,
-                seen=item.get("post_id", "") in seen_ids,
+                seen=f"{item.get('source', 'unknown')}:{item.get('post_id', '')}" in seen_ids,
             )
             self.append(ListItem(row))
         if items:

--- a/grokfeed/widgets/post_split_modal.py
+++ b/grokfeed/widgets/post_split_modal.py
@@ -12,6 +12,8 @@ INDENT = "  "
 
 
 class CommentWidget(Static):
+    """Renders an indented comment with author header and body."""
+
     DEFAULT_CSS = """
     CommentWidget {
         padding: 0 1;
@@ -136,6 +138,7 @@ class PostSplitModal(ModalScreen):
         self.run_worker(self._load_comments(), exclusive=True)
 
     async def _load_comments(self) -> None:
+        """Fetch comments asynchronously and mount them into the scroll pane."""
         from ..sources.comments import fetch_comments
 
         loading = self.query_one("#loading-comments", Label)
@@ -157,6 +160,7 @@ class PostSplitModal(ModalScreen):
             await scroll.mount(CommentWidget(c, self._source_color))
 
     def action_switch_pane(self) -> None:
+        """Toggle the active scroll pane between post body and comments."""
         self._active_pane = "comments" if self._active_pane == "post" else "post"
         if self._active_pane == "post":
             self.query_one("#pane-label-post", Label).update("▶ POST")
@@ -174,6 +178,7 @@ class PostSplitModal(ModalScreen):
         self.query_one(f"#{scroll_id}", ScrollableContainer).scroll_up()
 
     def action_open_url(self) -> None:
+        """Open the story URL in the system browser."""
         url = self._item.get("url")
         if url:
             self.app.open_url(url)

--- a/grokfeed/widgets/story.py
+++ b/grokfeed/widgets/story.py
@@ -44,6 +44,7 @@ class StoryRow(Static):
     """
 
     highlighted: reactive[bool] = reactive(False)
+    seen: reactive[bool] = reactive(False)
 
     def __init__(
         self,
@@ -53,6 +54,7 @@ class StoryRow(Static):
         comments: int,
         url: str,
         color: str,
+        seen: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -62,10 +64,11 @@ class StoryRow(Static):
         self.num_comments = comments
         self.url = url
         self.color = color
+        self.seen = seen
 
     def render(self) -> str:
         tag = f"[bold {self.color}][{self.source}][/]"
-        title = self.story_title
+        title = f"[dim]{self.story_title}[/]" if self.seen else self.story_title
         meta = f"[dim]▲{self.score:,}  💬{self.num_comments:,}[/]"
         return f"{tag} {title}\n{meta}"
 

--- a/grokfeed/widgets/story.py
+++ b/grokfeed/widgets/story.py
@@ -19,6 +19,7 @@ LOBSTERS_COLOR = "#ac130d"
 
 
 def source_color(source: str, subreddit_index: int) -> str:
+    """Return a hex color string for the given source."""
     if source == "HN":
         return HN_COLOR
     if source == "lobste.rs":
@@ -67,6 +68,7 @@ class StoryRow(Static):
         self.seen = seen
 
     def render(self) -> str:
+        """Render source tag, title (dimmed if seen), and score/comment counts."""
         tag = f"[bold {self.color}][{self.source}][/]"
         title = f"[dim]{self.story_title}[/]" if self.seen else self.story_title
         meta = f"[dim]▲{self.score:,}  💬{self.num_comments:,}[/]"

--- a/uv.lock
+++ b/uv.lock
@@ -155,7 +155,7 @@ toml = [
 
 [[package]]
 name = "grokfeed"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Opening a post (Enter) immediately dims its title in the feed
- Seen post IDs are persisted to `~/.grokfeed/seen.json` and survive restarts
- Entries older than 24 hours are pruned on every write
- Seen state is loaded at startup and applied when the feed renders

Closes #12 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opening or highlighting a post marks it as "seen" and dims its title in the list.
  * Seen state persists across sessions and automatically expires after 24 hours.
  * If persistence fails, a status warning is shown.

* **Chores**
  * Added and expanded in-app documentation to improve clarity and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->