### PR TITLE
feat: yank story URL to clipboard with y

### DIFF
--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -285,15 +285,17 @@ class GrokFeedApp(App):
         """Copy the highlighted story URL to the system clipboard."""
         item = self.query_one(FeedList).current_item()
         if not item:
+            self._set_status("Nothing to copy — no story selected")
             return
         url = item.get("url", "")
         if not url:
+            self._set_status("Nothing to copy — story has no URL")
             return
         if copy_to_clipboard(url):
             self._set_status(f"Copied: {url}")
         else:
             self._set_status(
-                "Copy failed — install xclip or xsel (Linux) to enable clipboard support"
+                "Copy failed — clipboard unavailable; ensure clipboard access or install platform clipboard tools"
             )
 
     def action_cycle_source(self) -> None:

--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -8,6 +8,7 @@ from textual.binding import Binding
 from textual.containers import Container
 from textual.widgets import Footer, Header, Label, LoadingIndicator
 
+from .clipboard import copy_to_clipboard
 from .config import Config, load_cache, save_cache
 from .sources.hn import fetch_hn_stories_by_ids, fetch_hn_top_ids
 from .sources.lobsters import fetch_lobsters_posts
@@ -69,6 +70,7 @@ class GrokFeedApp(App):
         Binding("f", "cycle_source", "Filter"),
         Binding("r", "refresh", "Refresh"),
         Binding("m", "load_more", "More"),
+        Binding("y", "yank_url", "Copy URL"),
         Binding("q", "quit", "Quit"),
     ]
 
@@ -278,6 +280,21 @@ class GrokFeedApp(App):
 
     def action_refresh(self) -> None:
         self.run_worker(self._load_all(), exclusive=True, name="fetch")
+
+    def action_yank_url(self) -> None:
+        """Copy the highlighted story URL to the system clipboard."""
+        item = self.query_one(FeedList).current_item()
+        if not item:
+            return
+        url = item.get("url", "")
+        if not url:
+            return
+        if copy_to_clipboard(url):
+            self._set_status(f"Copied: {url}")
+        else:
+            self._set_status(
+                "Copy failed — install xclip or xsel (Linux) to enable clipboard support"
+            )
 
     def action_cycle_source(self) -> None:
         if not self._sources:

--- a/grokfeed/clipboard.py
+++ b/grokfeed/clipboard.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def copy_to_clipboard(text: str) -> bool:
+    """Copy text to the system clipboard. Returns False if no clipboard tool is available."""
+    try:
+        if sys.platform == "darwin":
+            subprocess.run(["pbcopy"], input=text.encode(), check=True)
+        elif sys.platform == "win32":
+            subprocess.run(["clip"], input=text.encode(), check=True)
+        else:
+            # Linux: prefer xclip, fall back to xsel
+            try:
+                subprocess.run(
+                    ["xclip", "-selection", "clipboard"],
+                    input=text.encode(),
+                    check=True,
+                )
+            except FileNotFoundError:
+                subprocess.run(
+                    ["xsel", "--clipboard", "--input"],
+                    input=text.encode(),
+                    check=True,
+                )
+        return True
+    except Exception:
+        return False

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -1,0 +1,51 @@
+from subprocess import CalledProcessError
+from unittest.mock import patch
+
+from grokfeed.clipboard import copy_to_clipboard
+
+
+def test_copy_returns_true_on_success():
+    with patch("grokfeed.clipboard.subprocess.run") as mock_run:
+        mock_run.return_value = None
+        assert copy_to_clipboard("https://example.com") is True
+        assert mock_run.called
+
+
+def test_copy_passes_encoded_input():
+    with patch("grokfeed.clipboard.subprocess.run") as mock_run:
+        mock_run.return_value = None
+        copy_to_clipboard("https://example.com")
+        _, kwargs = mock_run.call_args
+        assert kwargs["input"] == b"https://example.com"
+
+
+def test_copy_returns_false_on_file_not_found():
+    with patch("grokfeed.clipboard.subprocess.run", side_effect=FileNotFoundError):
+        assert copy_to_clipboard("https://example.com") is False
+
+
+def test_copy_returns_false_on_subprocess_error():
+    with patch(
+        "grokfeed.clipboard.subprocess.run",
+        side_effect=CalledProcessError(1, "pbcopy"),
+    ):
+        assert copy_to_clipboard("https://example.com") is False
+
+
+def test_copy_linux_falls_back_to_xsel():
+    call_log: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> None:
+        call_log.append(cmd)
+        if cmd[0] == "xclip":
+            raise FileNotFoundError
+
+    with (
+        patch("grokfeed.clipboard.sys.platform", "linux"),
+        patch("grokfeed.clipboard.subprocess.run", side_effect=fake_run),
+    ):
+        result = copy_to_clipboard("https://example.com")
+
+    assert result is True
+    assert call_log[0][0] == "xclip"
+    assert call_log[1][0] == "xsel"


### PR DESCRIPTION
## Summary

- Press `y` on any focused story to copy its URL to the system clipboard
- Status bar shows `Copied: https://…` on success
- Status bar shows an actionable error message if no clipboard tool is found
- No new dependencies — uses `subprocess` with platform detection

## Implementation

- **`grokfeed/clipboard.py`** — new module: `copy_to_clipboard(text) -> bool`
  - macOS: `pbcopy`
  - Windows: `clip`
  - Linux: `xclip -selection clipboard`, falls back to `xsel --clipboard --input`
  - Returns `False` on any failure (tool missing, non-zero exit, etc.)
- **`app.py`** — `y` binding + `action_yank_url`: gets URL from focused item, calls `copy_to_clipboard`, updates status bar
- **`tests/test_clipboard.py`** — 5 tests covering success, encoded input, FileNotFoundError, CalledProcessError, and Linux xclip→xsel fallback

Closes #13 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (y) to copy feed item URLs to the system clipboard with cross-platform support (macOS, Windows, Linux).
  * Status bar now displays clear feedback for copied URLs, missing selection/URL, or unavailable clipboard tools.

* **Tests**
  * Added comprehensive tests for clipboard behavior and platform fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->