### PR TITLE
feat: keyword search with / shortcut

### DIFF
--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -8,7 +8,7 @@ import httpx
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Container
-from textual.widgets import Footer, Header, Label, LoadingIndicator
+from textual.widgets import Footer, Header, Input, Label, LoadingIndicator
 
 from .clipboard import copy_to_clipboard
 from .config import Config, load_cache, save_cache
@@ -19,6 +19,14 @@ from .sources.reddit import fetch_reddit_posts
 from .widgets.feed import FeedList
 from .widgets.post_split_modal import PostSplitModal
 from .widgets.story import source_color as get_source_color
+
+
+class _SearchInput(Input):
+    """Search bar that closes on Escape."""
+
+    def key_escape(self) -> None:
+        self.app.action_close_search()  # type: ignore[attr-defined]
+
 
 # Source filter sentinel
 ALL = "all"
@@ -69,6 +77,11 @@ class GrokFeedApp(App):
     LoadingIndicator {
         color: #ff6600;
     }
+    #search-bar {
+        dock: bottom;
+        height: 3;
+        display: none;
+    }
     """
 
     BINDINGS = [
@@ -81,6 +94,7 @@ class GrokFeedApp(App):
         Binding("r", "refresh", "Refresh"),
         Binding("m", "load_more", "More"),
         Binding("y", "yank_url", "Copy URL"),
+        Binding("/", "search", "Search"),
         Binding("q", "quit", "Quit"),
     ]
 
@@ -98,12 +112,14 @@ class GrokFeedApp(App):
         self._hn_offset: int = 0
         self._reddit_after: dict[str, str] = {}
         self._seen: set[str] = load_seen()
+        self._search_query: str = ""
 
     def compose(self) -> ComposeResult:
         yield Header()
         yield Label("", id="status-bar")
         yield Container(LoadingIndicator(), id="loading")
         yield FeedList(id="feed")
+        yield _SearchInput(placeholder="Search titles…", id="search-bar")
         yield Footer()
 
     def on_mount(self) -> None:
@@ -204,7 +220,7 @@ class GrokFeedApp(App):
         feed.display = True
 
     def _apply_filter(self, from_cache: bool = False) -> None:
-        """Re-render the feed list for the active source filter."""
+        """Re-render the feed list for the active source filter and search query."""
         feed = self.query_one(FeedList)
         if self._source_filter == ALL:
             visible = _interleave_by_score(self._all_items)
@@ -212,9 +228,13 @@ class GrokFeedApp(App):
         else:
             visible = [i for i in self._all_items if i["source"] == self._source_filter]
             label = self._source_filter
+        if self._search_query:
+            q = self._search_query.lower()
+            visible = [i for i in visible if q in i["title"].lower()]
         feed.load_items(visible, seen_ids=self._seen)
         suffix = " (cached)" if from_cache else ""
-        self._set_status(f"{len(visible)} stories — {label}{suffix}")
+        search_suffix = f" — search: {self._search_query}" if self._search_query else ""
+        self._set_status(f"{len(visible)} stories — {label}{suffix}{search_suffix}")
 
     def _set_status(self, msg: str) -> None:
         self.query_one("#status-bar", Label).update(msg)
@@ -324,6 +344,33 @@ class GrokFeedApp(App):
             self._set_status(
                 "Copy failed — clipboard unavailable; ensure clipboard access or install platform clipboard tools"
             )
+
+    def action_search(self) -> None:
+        """Open the search bar and focus it."""
+        bar = self.query_one("#search-bar", _SearchInput)
+        bar.display = True
+        bar.focus()
+
+    def action_close_search(self) -> None:
+        """Clear the search query, hide the bar, and restore the full feed."""
+        bar = self.query_one("#search-bar", _SearchInput)
+        bar.value = ""
+        bar.display = False
+        self._search_query = ""
+        self.query_one(FeedList).focus()
+        self._apply_filter()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Filter feed in real-time as the user types."""
+        if event.input.id == "search-bar":
+            self._search_query = event.value
+            self._apply_filter()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """On Enter, keep filter active but return focus to the feed list."""
+        if event.input.id == "search-bar":
+            event.input.display = False
+            self.query_one(FeedList).focus()
 
     def action_cycle_source(self) -> None:
         """Step through the source filter cycle (All → HN → subreddits → lobste.rs → …)."""

--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -113,6 +113,7 @@ class GrokFeedApp(App):
         self._reddit_after: dict[str, str] = {}
         self._seen: set[str] = load_seen()
         self._search_query: str = ""
+        self._from_cache: bool = False
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -128,6 +129,7 @@ class GrokFeedApp(App):
 
     async def _load_all(self) -> None:
         """Fetch all sources concurrently; serve from cache if still fresh."""
+        self._from_cache = False
         loading = self.query_one("#loading")
         feed = self.query_one(FeedList)
         loading.display = True
@@ -221,6 +223,7 @@ class GrokFeedApp(App):
 
     def _apply_filter(self, from_cache: bool = False) -> None:
         """Re-render the feed list for the active source filter and search query."""
+        self._from_cache = self._from_cache or from_cache
         feed = self.query_one(FeedList)
         if self._source_filter == ALL:
             visible = _interleave_by_score(self._all_items)
@@ -232,7 +235,7 @@ class GrokFeedApp(App):
             q = self._search_query.lower()
             visible = [i for i in visible if q in i["title"].lower()]
         feed.load_items(visible, seen_ids=self._seen)
-        suffix = " (cached)" if from_cache else ""
+        suffix = " (cached)" if self._from_cache else ""
         search_suffix = f" — search: {self._search_query}" if self._search_query else ""
         self._set_status(f"{len(visible)} stories — {label}{suffix}{search_suffix}")
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import time
+
+from grokfeed.app import _interleave_by_score
+
+# helpers
+
+
+def _item(title: str, source: str = "HN", score: int = 100) -> dict:
+    return {
+        "title": title,
+        "source": source,
+        "score": score,
+        "comments": 0,
+        "url": "https://example.com",
+        "body": "",
+        "post_id": title,
+        "created_at": time.time(),
+    }
+
+
+def _apply_search(items: list[dict], query: str) -> list[dict]:
+    """Reproduce the search filter logic from GrokFeedApp._apply_filter."""
+    q = query.lower()
+    return [i for i in items if q in i["title"].lower()]
+
+
+# tests
+
+
+def test_search_filters_by_title():
+    items = [_item("Rust memory safety"), _item("Python async tips"), _item("Rust vs Go")]
+    result = _apply_search(items, "rust")
+    assert len(result) == 2
+    assert all("rust" in i["title"].lower() for i in result)
+
+
+def test_search_case_insensitive():
+    items = [_item("Python Tutorial"), _item("python basics")]
+    result = _apply_search(items, "PYTHON")
+    assert len(result) == 2
+
+
+def test_search_empty_query_returns_all():
+    items = [_item("foo"), _item("bar"), _item("baz")]
+    result = _apply_search(items, "")
+    # empty query: the app skips the filter entirely, but filtering with "" matches all
+    assert len(result) == 3
+
+
+def test_search_no_match_returns_empty():
+    items = [_item("Rust tutorial"), _item("Go concurrency")]
+    result = _apply_search(items, "python")
+    assert result == []
+
+
+def test_search_partial_match():
+    items = [_item("Understanding async/await"), _item("async generators in Python")]
+    result = _apply_search(items, "async")
+    assert len(result) == 2
+
+
+def test_search_preserves_order():
+    now = time.time()
+    items = [
+        {**_item("Alpha post"), "score": 50, "created_at": now},
+        {**_item("Beta post"), "score": 200, "created_at": now},
+        {**_item("Gamma show"), "score": 300, "created_at": now},
+    ]
+    interleaved = _interleave_by_score(items)
+    result = _apply_search(interleaved, "post")
+    # both "post" items present, order determined by score
+    assert len(result) == 2
+    assert result[0]["title"] == "Beta post"
+    assert result[1]["title"] == "Alpha post"
+
+
+def test_search_across_sources():
+    items = [
+        _item("Python news", source="HN"),
+        _item("Python weekly", source="r/programming"),
+        _item("Go weekly", source="r/golang"),
+    ]
+    result = _apply_search(items, "python")
+    assert len(result) == 2
+    sources = {i["source"] for i in result}
+    assert "HN" in sources
+    assert "r/programming" in sources


### PR DESCRIPTION
## Summary

- Press `/` to open an inline search bar docked at the bottom of the screen
- Titles filter in real-time (case-insensitive) as you type
- `Enter` confirms the filter and returns focus to the feed list
- `Escape` clears the query and restores the full feed
- Search composes with the source filter (`f`) — both apply simultaneously

Closes #14 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-app search via `/`, bottom-docked input that focuses when opened; Escape clears and closes, Enter applies and closes
  * Filters feed items by title with case-insensitive substring matching
  * Active search shown in the status bar; cached indicator behavior improved

* **Tests**
  * Added comprehensive tests covering search matching, ordering, empty/no-match cases, and cross-source filtering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->