### PR TITLE
feat: add GitHub Trending source with README split view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,13 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: uv sync
-      - run: uv run pytest --cov=grokfeed --cov-report=xml
+      - run: uv run pytest --cov=grokfeed --cov-report=xml --cov-report=term-missing
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest' && matrix.python == '3.12'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   build-check:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="docs/img/grokfeed.png" alt="grokfeed" width="500"/>
 
 
-**Terminal feed reader for Hacker News, Reddit, and lobste.rs.**
+**Terminal feed reader for Hacker News, Reddit, lobste.rs, and GitHub Trending.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PyPI version](https://img.shields.io/pypi/v/grokfeed)](https://pypi.org/project/grokfeed/)
@@ -15,11 +15,12 @@
 
 ## Features
 
-- Unified scrollable feed from HN, Reddit subreddits, and lobste.rs
-- Color-coded by source: HN orange, lobste.rs red, subreddits in a cycling palette
+- Unified scrollable feed from HN, Reddit subreddits, lobste.rs, and GitHub Trending
+- Color-coded by source: HN orange, lobste.rs red, GitHub green, subreddits in a cycling palette
 - Read text posts and Ask HN inline — no browser needed
-- Split view with post body and threaded comments side by side
+- Split view with post body / repo stats and threaded comments or README side by side
 - Filter feed by source, refresh on demand, paginate with `m`
+- Keyword search with `/`, copy URL with `y`, mark seen posts dimmed automatically
 - Config file at `~/.grokfeed/config.toml` — created automatically on first run
 
 ## Install
@@ -66,6 +67,9 @@ subreddits = ["programming", "ClaudeAI", "machinelearning"]
 hn_story_count = 30
 reddit_post_count = 15
 lobsters_post_count = 25
+github_trending_count = 25
+# github_trending_language = "python"   # filter by language (optional)
+# github_trending_since = "daily"       # daily | weekly | monthly
 cache_ttl_minutes = 10
 ```
 
@@ -84,9 +88,11 @@ Run `grokfeed` — changes take effect on next launch or press `r` to refresh.
 | `j` / `↓` | Move down |
 | `k` / `↑` | Move up |
 | `Enter` | Open post + comments split view |
-| `f` | Cycle source filter (All → HN → r/sub → lobste.rs → …) |
+| `f` | Cycle source filter (All → HN → r/sub → lobste.rs → GitHub → …) |
 | `m` | Load more stories |
 | `r` | Refresh all sources |
+| `y` | Copy story URL to clipboard |
+| `/` | Keyword search |
 | `q` | Quit |
 
 ### Split view
@@ -95,7 +101,7 @@ Run `grokfeed` — changes take effect on next launch or press `r` to refresh.
 |-----|--------|
 | `j` / `↓` | Scroll down |
 | `k` / `↑` | Scroll up |
-| `Tab` | Switch between post and comments pane |
+| `Tab` | Switch between post/stats and comments/README pane |
 | `o` | Open URL in browser |
 | `q` / `Esc` | Close |
 
@@ -109,6 +115,9 @@ Run `grokfeed` — changes take effect on next launch or press `r` to refresh.
 | `hn_story_count` | `30` | HN stories per fetch |
 | `reddit_post_count` | `15` | Posts per subreddit per fetch |
 | `lobsters_post_count` | `25` | lobste.rs posts per fetch |
+| `github_trending_count` | `25` | GitHub trending repos per fetch |
+| `github_trending_language` | `""` | Filter by language (e.g. `"python"`), empty = all |
+| `github_trending_since` | `"daily"` | Trending window: `daily`, `weekly`, or `monthly` |
 | `cache_ttl_minutes` | `10` | Minutes before refreshing cache |
 
 ## Tech stack

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/grokfeed)](https://pypi.org/project/grokfeed/)
 [![GitHub release](https://img.shields.io/github/v/release/emarkou/grokfeed)](https://github.com/emarkou/grokfeed/releases/latest)
 [![CI](https://img.shields.io/github/actions/workflow/status/emarkou/grokfeed/ci.yml?branch=main&label=CI)](https://github.com/emarkou/grokfeed/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/emarkou/grokfeed/branch/main/graph/badge.svg)](https://codecov.io/gh/emarkou/grokfeed)
 
 </div>
 

--- a/grokfeed/app.py
+++ b/grokfeed/app.py
@@ -13,6 +13,7 @@ from textual.widgets import Footer, Header, Input, Label, LoadingIndicator
 from .clipboard import copy_to_clipboard
 from .config import Config, load_cache, save_cache
 from .seen import load_seen, mark_seen
+from .sources.github import fetch_github_trending
 from .sources.hn import fetch_hn_stories_by_ids, fetch_hn_top_ids
 from .sources.lobsters import fetch_lobsters_posts
 from .sources.reddit import fetch_reddit_posts
@@ -99,7 +100,7 @@ class GrokFeedApp(App):
     ]
 
     TITLE = "grokfeed"
-    SUB_TITLE = "HN + Reddit + lobste.rs terminal reader"
+    SUB_TITLE = "HN + Reddit + lobste.rs + GitHub terminal reader"
 
     def __init__(self, config: Config) -> None:
         super().__init__()
@@ -132,7 +133,7 @@ class GrokFeedApp(App):
         """Fetch all sources concurrently; render each source's items as they arrive."""
         self._from_cache = False
         self._all_items = []
-        self._pending_sources = {"HN", "Reddit", "lobste.rs"}
+        self._pending_sources = {"HN", "Reddit", "lobste.rs", "GitHub"}
         loading = self.query_one("#loading")
         feed = self.query_one(FeedList)
         loading.display = True
@@ -239,7 +240,35 @@ class GrokFeedApp(App):
                     self._pending_sources.discard("lobste.rs")
                     self._set_status(f"lobste.rs error: {e}")
 
-            await asyncio.gather(fetch_hn(), fetch_reddit(), fetch_lobsters())
+            async def fetch_github() -> None:
+                try:
+                    repos = await fetch_github_trending(
+                        self.config.github_trending_count,
+                        self.config.github_trending_language,
+                        self.config.github_trending_since,
+                        client,
+                    )
+                    _source_done(
+                        [
+                            {
+                                "title": r.title,
+                                "source": "GitHub",
+                                "score": r.stars_today,
+                                "comments": r.forks,
+                                "url": r.url,
+                                "body": r.body,
+                                "post_id": r.id,
+                                "created_at": r.created_at,
+                            }
+                            for r in repos
+                        ],
+                        "GitHub",
+                    )
+                except Exception as e:
+                    self._pending_sources.discard("GitHub")
+                    self._set_status(f"GitHub error: {e}")
+
+            await asyncio.gather(fetch_hn(), fetch_reddit(), fetch_lobsters(), fetch_github())
 
         if self._all_items:
             save_cache(self._all_items)

--- a/grokfeed/config.py
+++ b/grokfeed/config.py
@@ -19,6 +19,9 @@ subreddits = ["programming", "ClaudeAI", "machinelearning"]
 hn_story_count = 30
 reddit_post_count = 15
 lobsters_post_count = 25
+github_trending_count = 25
+# github_trending_language = "python"   # filter by language (optional)
+# github_trending_since = "daily"       # daily | weekly | monthly
 cache_ttl_minutes = 10
 """
 
@@ -33,6 +36,9 @@ class Config:
     hn_story_count: int = 30
     reddit_post_count: int = 15
     lobsters_post_count: int = 25
+    github_trending_count: int = 25
+    github_trending_language: str = ""
+    github_trending_since: str = "daily"
     cache_ttl_minutes: int = 10
 
 
@@ -50,6 +56,9 @@ def load_config() -> tuple[Config, bool]:
         hn_story_count=int(raw.get("hn_story_count", 30)),
         reddit_post_count=int(raw.get("reddit_post_count", 15)),
         lobsters_post_count=int(raw.get("lobsters_post_count", 25)),
+        github_trending_count=int(raw.get("github_trending_count", 25)),
+        github_trending_language=str(raw.get("github_trending_language", "")),
+        github_trending_since=str(raw.get("github_trending_since", "daily")),
         cache_ttl_minutes=int(raw.get("cache_ttl_minutes", 10)),
     ), created
 

--- a/grokfeed/sources/comments.py
+++ b/grokfeed/sources/comments.py
@@ -157,4 +157,11 @@ async def fetch_comments(item: dict) -> list[Comment]:
         return await fetch_reddit_comments(item["subreddit"], item["post_id"])
     elif source == "lobste.rs":
         return await fetch_lobsters_comments(item["post_id"])
+    elif source == "GitHub":
+        from .github import fetch_github_readme
+
+        readme = await fetch_github_readme(item["post_id"])
+        if readme:
+            return [Comment(author="README.md", score=0, body=readme, depth=0)]
+        return []
     return []

--- a/grokfeed/sources/github.py
+++ b/grokfeed/sources/github.py
@@ -70,7 +70,7 @@ def _parse_repos(html: str, count: int) -> list[GitHubRepo]:
         owner, name = parts
 
         # description
-        desc_m = re.search(r'<p\s[^>]*col-9[^>]*>(.*?)</p>', article, re.DOTALL)
+        desc_m = re.search(r"<p\s[^>]*col-9[^>]*>(.*?)</p>", article, re.DOTALL)
         description = ""
         if desc_m:
             description = re.sub(r"<[^>]+>", "", desc_m.group(1)).strip()
@@ -122,7 +122,9 @@ async def fetch_github_trending(
     client: httpx.AsyncClient | None = None,
 ) -> list[GitHubRepo]:
     """Scrape GitHub trending repos page."""
-    url = f"{TRENDING_URL}/{language}?since={since}" if language else f"{TRENDING_URL}?since={since}"
+    url = (
+        f"{TRENDING_URL}/{language}?since={since}" if language else f"{TRENDING_URL}?since={since}"
+    )
     headers = {"User-Agent": USER_AGENT}
 
     async def _run(c: httpx.AsyncClient) -> list[GitHubRepo]:

--- a/grokfeed/sources/github.py
+++ b/grokfeed/sources/github.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import base64
+import re
+import time
+from dataclasses import dataclass, field
+
+import httpx
+
+USER_AGENT = "grokfeed:v0.1.0 (terminal feed reader)"
+TRENDING_URL = "https://github.com/trending"
+README_API = "https://api.github.com/repos/{repo}/readme"
+
+
+@dataclass
+class GitHubRepo:
+    owner: str
+    name: str
+    description: str = ""
+    language: str = ""
+    stars: int = 0
+    stars_today: int = 0
+    forks: int = 0
+    created_at: int = field(default_factory=lambda: int(time.time()))
+
+    @property
+    def title(self) -> str:
+        return f"{self.owner}/{self.name}"
+
+    @property
+    def url(self) -> str:
+        return f"https://github.com/{self.owner}/{self.name}"
+
+    @property
+    def id(self) -> str:
+        return f"{self.owner}/{self.name}"
+
+    @property
+    def body(self) -> str:
+        """Markdown stats card for the split view left pane."""
+        rows = [
+            f"## {self.owner}/{self.name}\n",
+            f"{self.description}\n" if self.description else "",
+            "\n| | |\n|---|---|\n",
+            f"| ⭐ Stars | {self.stars:,} |\n",
+            f"| 🔥 Today | +{self.stars_today:,} stars |\n",
+            f"| 🍴 Forks | {self.forks:,} |\n",
+        ]
+        if self.language:
+            rows.append(f"| 💻 Language | {self.language} |\n")
+        return "".join(rows)
+
+
+def _parse_repos(html: str, count: int) -> list[GitHubRepo]:
+    repos: list[GitHubRepo] = []
+    for article in re.split(r"<article\b[^>]*>", html)[1:]:
+        if len(repos) >= count:
+            break
+
+        # owner/repo from h2 link
+        h2_m = re.search(r"<h2[^>]*>(.*?)</h2>", article, re.DOTALL)
+        if not h2_m:
+            continue
+        href_m = re.search(r'href="(/[^/"]+/[^/"]+)"', h2_m.group(1))
+        if not href_m:
+            continue
+        parts = href_m.group(1).strip("/").split("/")
+        if len(parts) != 2:
+            continue
+        owner, name = parts
+
+        # description
+        desc_m = re.search(r'<p\s[^>]*col-9[^>]*>(.*?)</p>', article, re.DOTALL)
+        description = ""
+        if desc_m:
+            description = re.sub(r"<[^>]+>", "", desc_m.group(1)).strip()
+
+        # language
+        lang_m = re.search(r'itemprop="programmingLanguage"[^>]*>(.*?)</span>', article)
+        language = lang_m.group(1).strip() if lang_m else ""
+
+        # total stars
+        stars_m = re.search(
+            rf'href="/{re.escape(owner)}/{re.escape(name)}/stargazers"[^>]*>'
+            r".*?([\d,]+)\s*</a>",
+            article,
+            re.DOTALL,
+        )
+        stars = int(stars_m.group(1).replace(",", "")) if stars_m else 0
+
+        # forks
+        forks_m = re.search(
+            rf'href="/{re.escape(owner)}/{re.escape(name)}/network/members"[^>]*>'
+            r".*?([\d,]+)\s*</a>",
+            article,
+            re.DOTALL,
+        )
+        forks = int(forks_m.group(1).replace(",", "")) if forks_m else 0
+
+        # stars today
+        today_m = re.search(r"([\d,]+)\s+stars?\s+today", article)
+        stars_today = int(today_m.group(1).replace(",", "")) if today_m else 0
+
+        repos.append(
+            GitHubRepo(
+                owner=owner,
+                name=name,
+                description=description,
+                language=language,
+                stars=stars,
+                stars_today=stars_today,
+                forks=forks,
+            )
+        )
+    return repos
+
+
+async def fetch_github_trending(
+    count: int = 25,
+    language: str = "",
+    since: str = "daily",
+    client: httpx.AsyncClient | None = None,
+) -> list[GitHubRepo]:
+    """Scrape GitHub trending repos page."""
+    url = f"{TRENDING_URL}/{language}?since={since}" if language else f"{TRENDING_URL}?since={since}"
+    headers = {"User-Agent": USER_AGENT}
+
+    async def _run(c: httpx.AsyncClient) -> list[GitHubRepo]:
+        try:
+            r = await c.get(url, timeout=15)
+            r.raise_for_status()
+            return _parse_repos(r.text, count)
+        except Exception:
+            return []
+
+    if client is not None:
+        return await _run(client)
+    async with httpx.AsyncClient(headers=headers) as c:
+        return await _run(c)
+
+
+async def fetch_github_readme(repo: str, client: httpx.AsyncClient | None = None) -> str:
+    """Fetch and decode the README for owner/repo. Returns empty string on failure."""
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": "application/vnd.github.v3+json",
+    }
+    url = README_API.format(repo=repo)
+
+    async def _run(c: httpx.AsyncClient) -> str:
+        try:
+            r = await c.get(url, timeout=15)
+            r.raise_for_status()
+            data = r.json()
+            if data.get("encoding") == "base64":
+                return base64.b64decode(data["content"]).decode("utf-8", errors="replace")
+            return ""
+        except Exception:
+            return ""
+
+    if client is not None:
+        return await _run(client)
+    async with httpx.AsyncClient(headers=headers) as c:
+        return await _run(c)

--- a/grokfeed/widgets/story.py
+++ b/grokfeed/widgets/story.py
@@ -16,6 +16,7 @@ SUBREDDIT_COLORS = [
 
 HN_COLOR = "#ff6600"
 LOBSTERS_COLOR = "#ac130d"
+GITHUB_COLOR = "#2ea44f"
 
 
 def source_color(source: str, subreddit_index: int) -> str:
@@ -24,6 +25,8 @@ def source_color(source: str, subreddit_index: int) -> str:
         return HN_COLOR
     if source == "lobste.rs":
         return LOBSTERS_COLOR
+    if source == "GitHub":
+        return GITHUB_COLOR
     return SUBREDDIT_COLORS[subreddit_index % len(SUBREDDIT_COLORS)]
 
 

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,6 +1,5 @@
 import base64
 
-import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -8,7 +7,6 @@ from grokfeed.sources.comments import (
     HN_ITEM,
     LOBSTERS_POST,
     REDDIT_COMMENTS,
-    Comment,
     _flatten_reddit,
     _strip_html,
     fetch_comments,
@@ -252,9 +250,7 @@ async def test_fetch_lobsters_comments_skips_empty_body(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         url=url,
         json={
-            "comments": [
-                {"comment": "", "commenting_user": "alice", "score": 0, "indent_level": 0}
-            ]
+            "comments": [{"comment": "", "commenting_user": "alice", "score": 0, "indent_level": 0}]
         },
     )
     comments = await fetch_lobsters_comments("emp1")
@@ -310,9 +306,7 @@ async def test_fetch_comments_dispatches_github_readme(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_fetch_comments_dispatches_github_no_readme(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
-        url=README_API.format(repo="owner/empty"), status_code=404
-    )
+    httpx_mock.add_response(url=README_API.format(repo="owner/empty"), status_code=404)
     result = await fetch_comments({"source": "GitHub", "post_id": "owner/empty"})
     assert result == []
 

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,0 +1,323 @@
+import base64
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from grokfeed.sources.comments import (
+    HN_ITEM,
+    LOBSTERS_POST,
+    REDDIT_COMMENTS,
+    Comment,
+    _flatten_reddit,
+    _strip_html,
+    fetch_comments,
+    fetch_hn_comments,
+    fetch_lobsters_comments,
+    fetch_reddit_comments,
+)
+from grokfeed.sources.github import README_API
+
+# ── _strip_html ─────────────────────────────────────────────────────────────────
+
+
+def test_strip_html_paragraph():
+    assert "\n\n" in _strip_html("before<p>after")
+
+
+def test_strip_html_removes_tags():
+    assert _strip_html("<b>bold</b>") == "bold"
+
+
+def test_strip_html_unescapes_entities():
+    assert _strip_html("&amp;&lt;&gt;") == "&<>"
+
+
+def test_strip_html_empty():
+    assert _strip_html("") == ""
+
+
+# ── _flatten_reddit ─────────────────────────────────────────────────────────────
+
+
+def _make_child(author: str, body: str, depth: int = 0, replies=None) -> dict:
+    child: dict = {
+        "kind": "t1",
+        "data": {"author": author, "body": body, "score": 10},
+    }
+    if replies:
+        child["data"]["replies"] = {"data": {"children": replies}}
+    else:
+        child["data"]["replies"] = ""
+    return child
+
+
+def test_flatten_reddit_single_comment():
+    children = [_make_child("alice", "hello")]
+    result = _flatten_reddit(children)
+    assert len(result) == 1
+    assert result[0].author == "alice"
+    assert result[0].body == "hello"
+    assert result[0].depth == 0
+
+
+def test_flatten_reddit_skips_deleted():
+    children = [
+        _make_child("alice", "[deleted]"),
+        _make_child("bob", "[removed]"),
+        _make_child("carol", "valid"),
+    ]
+    result = _flatten_reddit(children)
+    assert len(result) == 1
+    assert result[0].author == "carol"
+
+
+def test_flatten_reddit_skips_non_t1():
+    children = [{"kind": "more", "data": {}}, _make_child("alice", "hi")]
+    result = _flatten_reddit(children)
+    assert len(result) == 1
+
+
+def test_flatten_reddit_nested_replies():
+    reply = _make_child("child", "reply body")
+    parent = _make_child("parent", "parent body", replies=[reply])
+    result = _flatten_reddit([parent])
+    assert len(result) == 2
+    assert result[0].depth == 0
+    assert result[1].depth == 1
+
+
+def test_flatten_reddit_max_depth():
+    # Nest 5 deep — should stop at max_depth=2
+    inner = _make_child("d3", "deep")
+    mid = _make_child("d2", "mid", replies=[inner])
+    outer = _make_child("d1", "outer", replies=[mid])
+    result = _flatten_reddit([outer])
+    # d1 (depth 0), d2 (depth 1), d3 (depth 2) — d3's children are not included
+    assert len(result) == 3
+
+
+# ── fetch_hn_comments ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_hn_comments_basic(httpx_mock: HTTPXMock):
+    story_url = HN_ITEM.format(100)
+    comment_url = HN_ITEM.format(42)
+    httpx_mock.add_response(url=story_url, json={"kids": [42], "type": "story"})
+    httpx_mock.add_response(
+        url=comment_url,
+        json={"id": 42, "type": "comment", "by": "alice", "text": "hello world"},
+    )
+    comments = await fetch_hn_comments(100)
+    assert len(comments) == 1
+    assert comments[0].author == "alice"
+    assert comments[0].body == "hello world"
+    assert comments[0].score == 0  # HN API has no comment scores
+
+
+@pytest.mark.asyncio
+async def test_fetch_hn_comments_skips_deleted(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url=HN_ITEM.format(100), json={"kids": [42], "type": "story"})
+    httpx_mock.add_response(url=HN_ITEM.format(42), json={"deleted": True, "type": "comment"})
+    comments = await fetch_hn_comments(100)
+    assert comments == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_hn_comments_skips_dead(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url=HN_ITEM.format(100), json={"kids": [42], "type": "story"})
+    httpx_mock.add_response(
+        url=HN_ITEM.format(42), json={"dead": True, "type": "comment", "by": "x", "text": "y"}
+    )
+    comments = await fetch_hn_comments(100)
+    assert comments == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_hn_comments_no_kids(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url=HN_ITEM.format(100), json={"type": "story"})
+    comments = await fetch_hn_comments(100)
+    assert comments == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_hn_comments_http_error(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url=HN_ITEM.format(100), json={"kids": [42], "type": "story"})
+    httpx_mock.add_response(url=HN_ITEM.format(42), status_code=500)
+    comments = await fetch_hn_comments(100)
+    assert comments == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_hn_comments_strips_html(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url=HN_ITEM.format(1), json={"kids": [2], "type": "story"})
+    httpx_mock.add_response(
+        url=HN_ITEM.format(2),
+        json={"id": 2, "type": "comment", "by": "bob", "text": "<p>hello &amp; world"},
+    )
+    comments = await fetch_hn_comments(1)
+    assert "hello & world" in comments[0].body
+
+
+# ── fetch_reddit_comments ───────────────────────────────────────────────────────
+
+
+def _reddit_response(children: list) -> list:
+    return [
+        {"data": {}},
+        {"data": {"children": children}},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_reddit_comments_basic(httpx_mock: HTTPXMock):
+    url = REDDIT_COMMENTS.format(subreddit="python", post_id="abc123")
+    httpx_mock.add_response(
+        url=url,
+        json=_reddit_response([_make_child("alice", "great post")]),
+    )
+    comments = await fetch_reddit_comments("python", "abc123")
+    assert len(comments) == 1
+    assert comments[0].author == "alice"
+    assert comments[0].body == "great post"
+
+
+@pytest.mark.asyncio
+async def test_fetch_reddit_comments_http_error(httpx_mock: HTTPXMock):
+    url = REDDIT_COMMENTS.format(subreddit="python", post_id="bad")
+    httpx_mock.add_response(url=url, status_code=403)
+    comments = await fetch_reddit_comments("python", "bad")
+    assert comments == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_reddit_comments_malformed_response(httpx_mock: HTTPXMock):
+    url = REDDIT_COMMENTS.format(subreddit="python", post_id="xyz")
+    httpx_mock.add_response(url=url, json={"not": "a list"})
+    comments = await fetch_reddit_comments("python", "xyz")
+    assert comments == []
+
+
+# ── fetch_lobsters_comments ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_lobsters_comments_basic(httpx_mock: HTTPXMock):
+    url = LOBSTERS_POST.format(short_id="abcd")
+    httpx_mock.add_response(
+        url=url,
+        json={
+            "comments": [
+                {
+                    "comment": "<p>nice post",
+                    "commenting_user": "alice",
+                    "score": 5,
+                    "indent_level": 0,
+                }
+            ]
+        },
+    )
+    comments = await fetch_lobsters_comments("abcd")
+    assert len(comments) == 1
+    assert comments[0].author == "alice"
+    assert comments[0].score == 5
+    assert "nice post" in comments[0].body
+
+
+@pytest.mark.asyncio
+async def test_fetch_lobsters_comments_dict_user(httpx_mock: HTTPXMock):
+    url = LOBSTERS_POST.format(short_id="xyz1")
+    httpx_mock.add_response(
+        url=url,
+        json={
+            "comments": [
+                {
+                    "comment": "hello",
+                    "commenting_user": {"username": "bob"},
+                    "score": 2,
+                    "indent_level": 1,
+                }
+            ]
+        },
+    )
+    comments = await fetch_lobsters_comments("xyz1")
+    assert comments[0].author == "bob"
+    assert comments[0].depth == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_lobsters_comments_skips_empty_body(httpx_mock: HTTPXMock):
+    url = LOBSTERS_POST.format(short_id="emp1")
+    httpx_mock.add_response(
+        url=url,
+        json={
+            "comments": [
+                {"comment": "", "commenting_user": "alice", "score": 0, "indent_level": 0}
+            ]
+        },
+    )
+    comments = await fetch_lobsters_comments("emp1")
+    assert comments == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_lobsters_comments_http_error(httpx_mock: HTTPXMock):
+    url = LOBSTERS_POST.format(short_id="err1")
+    httpx_mock.add_response(url=url, status_code=500)
+    comments = await fetch_lobsters_comments("err1")
+    assert comments == []
+
+
+# ── fetch_comments dispatcher ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_comments_dispatches_hn(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url=HN_ITEM.format(42), json={"kids": [], "type": "story"})
+    result = await fetch_comments({"source": "HN", "post_id": "42"})
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_comments_dispatches_reddit(httpx_mock: HTTPXMock):
+    url = REDDIT_COMMENTS.format(subreddit="python", post_id="abc")
+    httpx_mock.add_response(url=url, json=_reddit_response([]))
+    result = await fetch_comments({"source": "r/python", "subreddit": "python", "post_id": "abc"})
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_comments_dispatches_lobsters(httpx_mock: HTTPXMock):
+    url = LOBSTERS_POST.format(short_id="xyz")
+    httpx_mock.add_response(url=url, json={"comments": []})
+    result = await fetch_comments({"source": "lobste.rs", "post_id": "xyz"})
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_comments_dispatches_github_readme(httpx_mock: HTTPXMock):
+    readme_content = base64.b64encode(b"# My Project\nAwesome repo.").decode()
+    httpx_mock.add_response(
+        url=README_API.format(repo="owner/repo"),
+        json={"encoding": "base64", "content": readme_content},
+    )
+    result = await fetch_comments({"source": "GitHub", "post_id": "owner/repo"})
+    assert len(result) == 1
+    assert result[0].author == "README.md"
+    assert "My Project" in result[0].body
+
+
+@pytest.mark.asyncio
+async def test_fetch_comments_dispatches_github_no_readme(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        url=README_API.format(repo="owner/empty"), status_code=404
+    )
+    result = await fetch_comments({"source": "GitHub", "post_id": "owner/empty"})
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_comments_unknown_source():
+    result = await fetch_comments({"source": "unknown", "post_id": "1"})
+    assert result == []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from grokfeed.config import Config
+from grokfeed.main import app
+
+
+def test_cli_help():
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "Hacker News" in result.output
+
+
+def test_cli_runs_app():
+    runner = CliRunner()
+    mock_app = MagicMock()
+    # GrokFeedApp and load_config are imported inside the command function,
+    # so patch them in the modules where they are defined.
+    with (
+        patch("grokfeed.app.GrokFeedApp", return_value=mock_app) as mock_class,
+        patch("grokfeed.config.load_config", return_value=(Config(), False)),
+    ):
+        result = runner.invoke(app)
+    assert result.exit_code == 0
+    mock_class.assert_called_once()
+    mock_app.run.assert_called_once()
+
+
+def test_cli_prints_config_message_on_first_run():
+    runner = CliRunner()
+    mock_app = MagicMock()
+    with (
+        patch("grokfeed.app.GrokFeedApp", return_value=mock_app),
+        patch("grokfeed.config.load_config", return_value=(Config(), True)),
+        patch("grokfeed.config.CONFIG_PATH", "/fake/path/config.toml"),
+    ):
+        result = runner.invoke(app)
+    assert "Config created" in result.output
+
+
+def test_cli_no_config_message_on_existing_config():
+    runner = CliRunner()
+    mock_app = MagicMock()
+    with (
+        patch("grokfeed.app.GrokFeedApp", return_value=mock_app),
+        patch("grokfeed.config.load_config", return_value=(Config(), False)),
+    ):
+        result = runner.invoke(app)
+    assert "Config created" not in result.output

--- a/tests/test_seen.py
+++ b/tests/test_seen.py
@@ -6,7 +6,6 @@ import pytest
 import grokfeed.seen as seen_module
 from grokfeed.seen import _load_raw, _valid_ts, load_seen, mark_seen
 
-
 # ── _valid_ts ──────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_seen.py
+++ b/tests/test_seen.py
@@ -1,0 +1,159 @@
+import json
+import time
+
+import pytest
+
+import grokfeed.seen as seen_module
+from grokfeed.seen import _load_raw, _valid_ts, load_seen, mark_seen
+
+
+# ── _valid_ts ──────────────────────────────────────────────────────────────────
+
+
+def test_valid_ts_float():
+    assert _valid_ts(1234567890.0) == pytest.approx(1234567890.0)
+
+
+def test_valid_ts_int():
+    assert _valid_ts(1234567890) == pytest.approx(1234567890.0)
+
+
+def test_valid_ts_numeric_string():
+    assert _valid_ts("1234567890") == pytest.approx(1234567890.0)
+
+
+def test_valid_ts_none():
+    assert _valid_ts(None) is None
+
+
+def test_valid_ts_non_numeric_string():
+    assert _valid_ts("not-a-number") is None
+
+
+def test_valid_ts_list():
+    assert _valid_ts([1, 2]) is None
+
+
+# ── _load_raw ──────────────────────────────────────────────────────────────────
+
+
+def test_load_raw_missing_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(seen_module, "SEEN_PATH", tmp_path / "missing.json")
+    assert _load_raw() == {}
+
+
+def test_load_raw_invalid_json(monkeypatch, tmp_path):
+    p = tmp_path / "seen.json"
+    p.write_text("not json ][")
+    monkeypatch.setattr(seen_module, "SEEN_PATH", p)
+    assert _load_raw() == {}
+
+
+def test_load_raw_non_dict_root(monkeypatch, tmp_path):
+    p = tmp_path / "seen.json"
+    p.write_text("[1, 2, 3]")
+    monkeypatch.setattr(seen_module, "SEEN_PATH", p)
+    assert _load_raw() == {}
+
+
+def test_load_raw_skips_invalid_timestamps(monkeypatch, tmp_path):
+    p = tmp_path / "seen.json"
+    p.write_text(json.dumps({"HN:1": 1700000000.0, "HN:2": "bad"}))
+    monkeypatch.setattr(seen_module, "SEEN_PATH", p)
+    result = _load_raw()
+    assert "HN:1" in result
+    assert "HN:2" not in result
+
+
+def test_load_raw_returns_all_valid(monkeypatch, tmp_path):
+    p = tmp_path / "seen.json"
+    data = {"a": 1.0, "b": 2.0, "c": 3.0}
+    p.write_text(json.dumps(data))
+    monkeypatch.setattr(seen_module, "SEEN_PATH", p)
+    assert _load_raw() == data
+
+
+# ── load_seen ──────────────────────────────────────────────────────────────────
+
+
+def test_load_seen_returns_empty_when_no_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(seen_module, "SEEN_PATH", tmp_path / "missing.json")
+    assert load_seen() == set()
+
+
+def test_load_seen_returns_recent_ids(monkeypatch, tmp_path):
+    p = tmp_path / "seen.json"
+    now = time.time()
+    p.write_text(json.dumps({"HN:1": now, "HN:2": now - 3600}))
+    monkeypatch.setattr(seen_module, "SEEN_PATH", p)
+    result = load_seen()
+    assert "HN:1" in result
+    assert "HN:2" in result
+
+
+def test_load_seen_excludes_expired(monkeypatch, tmp_path):
+    p = tmp_path / "seen.json"
+    old_ts = time.time() - 90_000  # > 24h TTL
+    now = time.time()
+    p.write_text(json.dumps({"HN:old": old_ts, "HN:new": now}))
+    monkeypatch.setattr(seen_module, "SEEN_PATH", p)
+    result = load_seen()
+    assert "HN:old" not in result
+    assert "HN:new" in result
+
+
+def test_load_seen_empty_file(monkeypatch, tmp_path):
+    p = tmp_path / "seen.json"
+    p.write_text("{}")
+    monkeypatch.setattr(seen_module, "SEEN_PATH", p)
+    assert load_seen() == set()
+
+
+# ── mark_seen ──────────────────────────────────────────────────────────────────
+
+
+def test_mark_seen_creates_file(monkeypatch, tmp_path):
+    seen_path = tmp_path / "seen.json"
+    monkeypatch.setattr(seen_module, "SEEN_PATH", seen_path)
+    monkeypatch.setattr(seen_module, "CONFIG_DIR", tmp_path)
+    assert mark_seen("HN:42") is True
+    assert seen_path.exists()
+
+
+def test_mark_seen_persists_id(monkeypatch, tmp_path):
+    seen_path = tmp_path / "seen.json"
+    monkeypatch.setattr(seen_module, "SEEN_PATH", seen_path)
+    monkeypatch.setattr(seen_module, "CONFIG_DIR", tmp_path)
+    mark_seen("HN:99")
+    data = json.loads(seen_path.read_text())
+    assert "HN:99" in data
+
+
+def test_mark_seen_prunes_expired(monkeypatch, tmp_path):
+    seen_path = tmp_path / "seen.json"
+    old_ts = time.time() - 90_000
+    seen_path.write_text(json.dumps({"HN:old": old_ts}))
+    monkeypatch.setattr(seen_module, "SEEN_PATH", seen_path)
+    monkeypatch.setattr(seen_module, "CONFIG_DIR", tmp_path)
+    mark_seen("HN:new")
+    data = json.loads(seen_path.read_text())
+    assert "HN:old" not in data
+    assert "HN:new" in data
+
+
+def test_mark_seen_overwrites_existing_id(monkeypatch, tmp_path):
+    seen_path = tmp_path / "seen.json"
+    old_ts = time.time() - 100
+    seen_path.write_text(json.dumps({"HN:1": old_ts}))
+    monkeypatch.setattr(seen_module, "SEEN_PATH", seen_path)
+    monkeypatch.setattr(seen_module, "CONFIG_DIR", tmp_path)
+    mark_seen("HN:1")
+    data = json.loads(seen_path.read_text())
+    assert data["HN:1"] > old_ts
+
+
+def test_mark_seen_returns_false_on_write_failure(monkeypatch, tmp_path):
+    # SEEN_PATH points to an existing directory — write_text will fail
+    monkeypatch.setattr(seen_module, "SEEN_PATH", tmp_path)
+    monkeypatch.setattr(seen_module, "CONFIG_DIR", tmp_path)
+    assert mark_seen("HN:42") is False

--- a/tests/test_sources_github.py
+++ b/tests/test_sources_github.py
@@ -137,3 +137,51 @@ async def test_fetch_github_readme_with_client(httpx_mock: HTTPXMock):
     async with httpx.AsyncClient() as client:
         readme = await fetch_github_readme("owner/repo", client=client)
     assert readme == "readme content"
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_trending_with_client(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url=f"{TRENDING_URL}?since=daily", text=TRENDING_HTML)
+    async with httpx.AsyncClient() as client:
+        repos = await fetch_github_trending(count=10, client=client)
+    assert len(repos) == 2
+
+
+def test_parse_repos_missing_stars_forks_today():
+    # Article with no star/fork/today spans — should default to 0
+    html = """
+    <article class="Box-row">
+      <h2 class="h3"><a href="/owner/nometrics">owner / nometrics</a></h2>
+      <p class="col-9 color-fg-muted my-1 pr-4">No metrics here</p>
+    </article>
+    """
+    repos = _parse_repos(html, count=10)
+    assert len(repos) == 1
+    assert repos[0].stars == 0
+    assert repos[0].forks == 0
+    assert repos[0].stars_today == 0
+
+
+def test_parse_repos_no_language():
+    html = """
+    <article class="Box-row">
+      <h2 class="h3"><a href="/owner/repo">owner / repo</a></h2>
+    </article>
+    """
+    repos = _parse_repos(html, count=10)
+    assert len(repos) == 1
+    assert repos[0].language == ""
+
+
+def test_parse_repos_skips_bad_href():
+    html = """
+    <article class="Box-row">
+      <h2 class="h3"><a href="/only-one-part">bad</a></h2>
+    </article>
+    <article class="Box-row">
+      <h2 class="h3"><a href="/owner/repo">owner / repo</a></h2>
+    </article>
+    """
+    repos = _parse_repos(html, count=10)
+    assert len(repos) == 1
+    assert repos[0].owner == "owner"

--- a/tests/test_sources_github.py
+++ b/tests/test_sources_github.py
@@ -5,11 +5,11 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from grokfeed.sources.github import (
-    TRENDING_URL,
     README_API,
+    TRENDING_URL,
     _parse_repos,
-    fetch_github_trending,
     fetch_github_readme,
+    fetch_github_trending,
 )
 
 # Minimal trending page HTML with two repos

--- a/tests/test_sources_github.py
+++ b/tests/test_sources_github.py
@@ -1,0 +1,139 @@
+import base64
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from grokfeed.sources.github import (
+    TRENDING_URL,
+    README_API,
+    _parse_repos,
+    fetch_github_trending,
+    fetch_github_readme,
+)
+
+# Minimal trending page HTML with two repos
+TRENDING_HTML = """
+<html><body>
+<article class="Box-row">
+  <h2 class="h3 lh-condensed">
+    <a href="/octocat/Hello-World">octocat / Hello-World</a>
+  </h2>
+  <p class="col-9 color-fg-muted my-1 pr-4">My first repository on GitHub!</p>
+  <span itemprop="programmingLanguage">Python</span>
+  <a class="Link--muted" href="/octocat/Hello-World/stargazers">1,234</a>
+  <a class="Link--muted" href="/octocat/Hello-World/network/members">567</a>
+  <span>89 stars today</span>
+</article>
+<article class="Box-row">
+  <h2 class="h3 lh-condensed">
+    <a href="/torvalds/linux">torvalds / linux</a>
+  </h2>
+  <p class="col-9 color-fg-muted my-1 pr-4">Linux kernel source tree</p>
+  <span itemprop="programmingLanguage">C</span>
+  <a class="Link--muted" href="/torvalds/linux/stargazers">200,000</a>
+  <a class="Link--muted" href="/torvalds/linux/network/members">50,000</a>
+  <span>500 stars today</span>
+</article>
+</body></html>
+"""
+
+
+def test_parse_repos_count():
+    repos = _parse_repos(TRENDING_HTML, count=10)
+    assert len(repos) == 2
+
+
+def test_parse_repos_fields():
+    repos = _parse_repos(TRENDING_HTML, count=10)
+    r = repos[0]
+    assert r.owner == "octocat"
+    assert r.name == "Hello-World"
+    assert r.description == "My first repository on GitHub!"
+    assert r.language == "Python"
+    assert r.stars == 1234
+    assert r.forks == 567
+    assert r.stars_today == 89
+
+
+def test_parse_repos_respects_count():
+    repos = _parse_repos(TRENDING_HTML, count=1)
+    assert len(repos) == 1
+    assert repos[0].owner == "octocat"
+
+
+def test_parse_repos_title_and_url():
+    repos = _parse_repos(TRENDING_HTML, count=10)
+    r = repos[1]
+    assert r.title == "torvalds/linux"
+    assert r.url == "https://github.com/torvalds/linux"
+    assert r.id == "torvalds/linux"
+
+
+def test_parse_repos_body_contains_stats():
+    repos = _parse_repos(TRENDING_HTML, count=10)
+    body = repos[0].body
+    assert "1,234" in body
+    assert "+89" in body
+    assert "Python" in body
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_trending(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        url=f"{TRENDING_URL}?since=daily",
+        text=TRENDING_HTML,
+    )
+    repos = await fetch_github_trending(count=10, language="", since="daily")
+    assert len(repos) == 2
+    assert repos[0].owner == "octocat"
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_trending_with_language(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        url=f"{TRENDING_URL}/python?since=weekly",
+        text=TRENDING_HTML,
+    )
+    repos = await fetch_github_trending(count=10, language="python", since="weekly")
+    assert len(repos) == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_trending_http_error(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url=f"{TRENDING_URL}?since=daily", status_code=503)
+    repos = await fetch_github_trending()
+    assert repos == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_readme(httpx_mock: HTTPXMock):
+    content = base64.b64encode(b"# Hello\nThis is the README.").decode()
+    httpx_mock.add_response(
+        url=README_API.format(repo="octocat/Hello-World"),
+        json={"encoding": "base64", "content": content},
+    )
+    readme = await fetch_github_readme("octocat/Hello-World")
+    assert readme == "# Hello\nThis is the README."
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_readme_failure(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        url=README_API.format(repo="octocat/missing"),
+        status_code=404,
+    )
+    readme = await fetch_github_readme("octocat/missing")
+    assert readme == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_readme_with_client(httpx_mock: HTTPXMock):
+    content = base64.b64encode(b"readme content").decode()
+    httpx_mock.add_response(
+        url=README_API.format(repo="owner/repo"),
+        json={"encoding": "base64", "content": content},
+    )
+    async with httpx.AsyncClient() as client:
+        readme = await fetch_github_readme("owner/repo", client=client)
+    assert readme == "readme content"

--- a/tests/test_story.py
+++ b/tests/test_story.py
@@ -1,0 +1,36 @@
+from grokfeed.widgets.story import (
+    GITHUB_COLOR,
+    HN_COLOR,
+    LOBSTERS_COLOR,
+    SUBREDDIT_COLORS,
+    source_color,
+)
+
+
+def test_source_color_hn():
+    assert source_color("HN", 0) == HN_COLOR
+
+
+def test_source_color_lobsters():
+    assert source_color("lobste.rs", 0) == LOBSTERS_COLOR
+
+
+def test_source_color_github():
+    assert source_color("GitHub", 0) == GITHUB_COLOR
+
+
+def test_source_color_subreddit_returns_palette_color():
+    assert source_color("r/python", 0) == SUBREDDIT_COLORS[0]
+    assert source_color("r/python", 1) == SUBREDDIT_COLORS[1]
+
+
+def test_source_color_subreddit_wraps_around():
+    n = len(SUBREDDIT_COLORS)
+    assert source_color("r/sub", 0) == source_color("r/sub", n)
+    assert source_color("r/sub", 1) == source_color("r/sub", n + 1)
+
+
+def test_source_color_all_subreddit_slots_distinct():
+    n = len(SUBREDDIT_COLORS)
+    colors = [source_color(f"r/sub{i}", i) for i in range(n)]
+    assert len(set(colors)) == n

--- a/uv.lock
+++ b/uv.lock
@@ -155,7 +155,7 @@ toml = [
 
 [[package]]
 name = "grokfeed"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Adds GitHub Trending as a fourth feed source, scraped from `github.com/trending`
- Opening a repo shows a stats card (stars, forks, language, today's gain) on the left pane and the README fetched via GitHub API on the right pane
- Stars today used as interleaving score; forks shown as secondary metric
- Source tag rendered in GitHub green (`#2ea44f`)

## Config

Three new optional keys in `~/.grokfeed/config.toml`:

```toml
github_trending_count = 25
# github_trending_language = "python"   # filter by language
# github_trending_since = "daily"       # daily | weekly | monthly
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub Trending added as a fourth unified feed source
  * Configurable GitHub Trending options: repository count, optional language filter, and time window
  * New keyboard shortcuts: cycle source filter (incl. GitHub), refresh all, copy URL, search, and Tab behavior in split view

* **Documentation**
  * README updated with GitHub Trending details, settings, and shortcut docs

* **Tests**
  * Comprehensive tests for GitHub source, README-backed comments, comment processing, CLI, seen-state, and UI color mapping

* **Chores**
  * CI: enhanced coverage reporting and tolerant coverage upload behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emarkou/grokfeed/pull/22)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->