### PR TITLE
feat: respect terminal background theme

### DIFF
--- a/devskim/app.py
+++ b/devskim/app.py
@@ -141,11 +141,11 @@ class DevSkimApp(App):
 
     def __init__(self, config: Config) -> None:
         super().__init__()
-        if config.theme == "auto":
-            self.dark = _terminal_is_dark()
-        else:
-            self.dark = config.theme != "light"
         self.config = config
+        if config.theme == "auto":
+            self._initial_dark = _terminal_is_dark()
+        else:
+            self._initial_dark = config.theme != "light"
         self._all_items: list[dict] = []
         self._source_filter: str = ALL
         self._sources: list[str] = []
@@ -167,6 +167,7 @@ class DevSkimApp(App):
         yield Footer()
 
     def on_mount(self) -> None:
+        self.dark = self._initial_dark
         self.query_one("#feed").display = False
         self.run_worker(self._load_all(), exclusive=True, name="fetch")
 

--- a/devskim/app.py
+++ b/devskim/app.py
@@ -146,6 +146,8 @@ class DevSkimApp(App):
             self._initial_dark = _terminal_is_dark()
         else:
             self._initial_dark = config.theme != "light"
+        # theme can only be set after mount; stash name for on_mount
+        self._textual_theme = "textual-dark" if self._initial_dark else "textual-light"
         self._all_items: list[dict] = []
         self._source_filter: str = ALL
         self._sources: list[str] = []
@@ -167,7 +169,7 @@ class DevSkimApp(App):
         yield Footer()
 
     def on_mount(self) -> None:
-        self.dark = self._initial_dark
+        self.theme = self._textual_theme
         self.query_one("#feed").display = False
         self.run_worker(self._load_all(), exclusive=True, name="fetch")
 

--- a/devskim/app.py
+++ b/devskim/app.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import math
+import os
+import select
+import sys
+import termios
 import time as _time
+import tty
 
 import httpx
 from textual.app import App, ComposeResult
@@ -20,6 +25,39 @@ from .sources.reddit import fetch_reddit_posts
 from .widgets.feed import FeedList
 from .widgets.post_split_modal import PostSplitModal
 from .widgets.story import source_color as get_source_color
+
+
+def _terminal_is_dark() -> bool:
+    """Query terminal background via OSC 11. Returns True if dark (or unknown)."""
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        return True
+    try:
+        fd = sys.stdin.fileno()
+        old = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            os.write(sys.stdout.fileno(), b"\033]11;?\033\\")
+            ready, _, _ = select.select([sys.stdin], [], [], 0.2)
+            if not ready:
+                return True
+            buf = b""
+            while True:
+                r, _, _ = select.select([sys.stdin], [], [], 0.05)
+                if not r:
+                    break
+                buf += os.read(fd, 64)
+                if buf.endswith(b"\\") or b"\x07" in buf:
+                    break
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+        text = buf.decode("latin-1")
+        if "rgb:" in text:
+            parts = text.split("rgb:")[1].rstrip("\\\x07\x1b").split("/")
+            rv, gv, bv = int(parts[0][:2], 16), int(parts[1][:2], 16), int(parts[2][:2], 16)
+            return (0.299 * rv + 0.587 * gv + 0.114 * bv) < 128
+    except Exception:
+        pass
+    return True
 
 
 class _SearchInput(Input):
@@ -103,7 +141,10 @@ class DevSkimApp(App):
 
     def __init__(self, config: Config) -> None:
         super().__init__()
-        self.dark = config.theme != "light"
+        if config.theme == "auto":
+            self.dark = _terminal_is_dark()
+        else:
+            self.dark = config.theme != "light"
         self.config = config
         self._all_items: list[dict] = []
         self._source_filter: str = ALL

--- a/devskim/app.py
+++ b/devskim/app.py
@@ -61,6 +61,7 @@ class DevSkimApp(App):
 
     CSS = """
     Screen {
+        background: transparent;
         overflow-y: hidden;
     }
     #status-bar {

--- a/devskim/app.py
+++ b/devskim/app.py
@@ -61,7 +61,6 @@ class DevSkimApp(App):
 
     CSS = """
     Screen {
-        background: transparent;
         overflow-y: hidden;
     }
     #status-bar {
@@ -104,6 +103,7 @@ class DevSkimApp(App):
 
     def __init__(self, config: Config) -> None:
         super().__init__()
+        self.dark = config.theme != "light"
         self.config = config
         self._all_items: list[dict] = []
         self._source_filter: str = ALL

--- a/devskim/app.py
+++ b/devskim/app.py
@@ -61,7 +61,6 @@ class DevSkimApp(App):
 
     CSS = """
     Screen {
-        background: $surface;
         overflow-y: hidden;
     }
     #status-bar {
@@ -76,7 +75,7 @@ class DevSkimApp(App):
         align: center middle;
     }
     LoadingIndicator {
-        color: #ff6600;
+        color: $accent;
     }
     #search-bar {
         dock: bottom;

--- a/devskim/app.py
+++ b/devskim/app.py
@@ -5,9 +5,7 @@ import math
 import os
 import select
 import sys
-import termios
 import time as _time
-import tty
 
 import httpx
 from textual.app import App, ComposeResult
@@ -28,28 +26,41 @@ from .widgets.story import source_color as get_source_color
 
 
 def _terminal_is_dark() -> bool:
-    """Query terminal background via OSC 11. Returns True if dark (or unknown)."""
-    if not sys.stdin.isatty() or not sys.stdout.isatty():
+    """Query terminal background via OSC 11. Returns True if dark (or unknown).
+
+    Opens the controlling TTY directly via os.ctermid() to avoid touching
+    Textual's stdin. POSIX-only; returns True immediately on other platforms.
+    """
+    if sys.platform == "win32":
         return True
     try:
-        fd = sys.stdin.fileno()
-        old = termios.tcgetattr(fd)
+        import termios
+        import tty
+    except ImportError:
+        return True
+    try:
+        tty_path = os.ctermid()
+        fd = os.open(tty_path, os.O_RDWR | os.O_NOCTTY)
         try:
-            tty.setraw(fd)
-            os.write(sys.stdout.fileno(), b"\033]11;?\033\\")
-            ready, _, _ = select.select([sys.stdin], [], [], 0.2)
-            if not ready:
-                return True
-            buf = b""
-            while True:
-                r, _, _ = select.select([sys.stdin], [], [], 0.05)
-                if not r:
-                    break
-                buf += os.read(fd, 64)
-                if buf.endswith(b"\\") or b"\x07" in buf:
-                    break
+            old = termios.tcgetattr(fd)
+            try:
+                tty.setraw(fd)
+                os.write(fd, b"\033]11;?\033\\")
+                ready, _, _ = select.select([fd], [], [], 0.2)
+                if not ready:
+                    return True
+                buf = b""
+                while True:
+                    r, _, _ = select.select([fd], [], [], 0.05)
+                    if not r:
+                        break
+                    buf += os.read(fd, 64)
+                    if buf.endswith(b"\\") or b"\x07" in buf:
+                        break
+            finally:
+                termios.tcsetattr(fd, termios.TCSADRAIN, old)
         finally:
-            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+            os.close(fd)
         text = buf.decode("latin-1")
         if "rgb:" in text:
             parts = text.split("rgb:")[1].rstrip("\\\x07\x1b").split("/")

--- a/devskim/config.py
+++ b/devskim/config.py
@@ -53,7 +53,7 @@ github_trending_count = 25
 # github_trending_language = "python"   # filter by language (optional)
 # github_trending_since = "daily"       # daily | weekly | monthly
 cache_ttl_minutes = 10
-# theme = "light"                       # "dark" (default) or "light"
+# theme = "auto"                        # auto (default), dark, or light
 """
 
 
@@ -71,7 +71,7 @@ class Config:
     github_trending_language: str = ""
     github_trending_since: str = "daily"
     cache_ttl_minutes: int = 10
-    theme: str = "dark"
+    theme: str = "auto"
 
 
 def load_config() -> tuple[Config, bool]:
@@ -92,7 +92,7 @@ def load_config() -> tuple[Config, bool]:
         github_trending_language=str(raw.get("github_trending_language", "")),
         github_trending_since=str(raw.get("github_trending_since", "daily")),
         cache_ttl_minutes=int(raw.get("cache_ttl_minutes", 10)),
-        theme=str(raw.get("theme", "dark")),
+        theme=str(raw.get("theme", "auto")),
     ), created
 
 

--- a/devskim/config.py
+++ b/devskim/config.py
@@ -53,6 +53,7 @@ github_trending_count = 25
 # github_trending_language = "python"   # filter by language (optional)
 # github_trending_since = "daily"       # daily | weekly | monthly
 cache_ttl_minutes = 10
+# theme = "light"                       # "dark" (default) or "light"
 """
 
 
@@ -70,6 +71,7 @@ class Config:
     github_trending_language: str = ""
     github_trending_since: str = "daily"
     cache_ttl_minutes: int = 10
+    theme: str = "dark"
 
 
 def load_config() -> tuple[Config, bool]:
@@ -90,6 +92,7 @@ def load_config() -> tuple[Config, bool]:
         github_trending_language=str(raw.get("github_trending_language", "")),
         github_trending_since=str(raw.get("github_trending_since", "daily")),
         cache_ttl_minutes=int(raw.get("cache_ttl_minutes", 10)),
+        theme=str(raw.get("theme", "dark")),
     ), created
 
 

--- a/devskim/widgets/comments_modal.py
+++ b/devskim/widgets/comments_modal.py
@@ -56,7 +56,6 @@ class CommentsModal(ModalScreen):
     CommentsModal > Vertical {
         width: 90%;
         height: 90%;
-        background: transparent;
         border: thick $primary;
         padding: 0 1;
     }

--- a/devskim/widgets/comments_modal.py
+++ b/devskim/widgets/comments_modal.py
@@ -56,7 +56,6 @@ class CommentsModal(ModalScreen):
     CommentsModal > Vertical {
         width: 90%;
         height: 90%;
-        background: $surface;
         border: thick $primary;
         padding: 0 1;
     }

--- a/devskim/widgets/comments_modal.py
+++ b/devskim/widgets/comments_modal.py
@@ -56,6 +56,7 @@ class CommentsModal(ModalScreen):
     CommentsModal > Vertical {
         width: 90%;
         height: 90%;
+        background: transparent;
         border: thick $primary;
         padding: 0 1;
     }

--- a/devskim/widgets/content_modal.py
+++ b/devskim/widgets/content_modal.py
@@ -28,7 +28,6 @@ class ContentModal(ModalScreen):
     ContentModal > Vertical {
         width: 90%;
         height: 85%;
-        background: transparent;
         border: thick $primary;
         padding: 0 1;
     }

--- a/devskim/widgets/content_modal.py
+++ b/devskim/widgets/content_modal.py
@@ -28,7 +28,6 @@ class ContentModal(ModalScreen):
     ContentModal > Vertical {
         width: 90%;
         height: 85%;
-        background: $surface;
         border: thick $primary;
         padding: 0 1;
     }

--- a/devskim/widgets/content_modal.py
+++ b/devskim/widgets/content_modal.py
@@ -28,6 +28,7 @@ class ContentModal(ModalScreen):
     ContentModal > Vertical {
         width: 90%;
         height: 85%;
+        background: transparent;
         border: thick $primary;
         padding: 0 1;
     }

--- a/devskim/widgets/feed.py
+++ b/devskim/widgets/feed.py
@@ -11,12 +11,10 @@ class FeedList(ListView):
     DEFAULT_CSS = """
     FeedList {
         height: 1fr;
-        background: $surface;
     }
     FeedList ListItem {
         height: 3;
         padding: 0;
-        background: $surface;
     }
     FeedList ListItem.-highlight {
         background: $primary-darken-2;

--- a/devskim/widgets/feed.py
+++ b/devskim/widgets/feed.py
@@ -11,10 +11,12 @@ class FeedList(ListView):
     DEFAULT_CSS = """
     FeedList {
         height: 1fr;
+        background: transparent;
     }
     FeedList ListItem {
         height: 3;
         padding: 0;
+        background: transparent;
     }
     FeedList ListItem.-highlight {
         background: $primary-darken-2;

--- a/devskim/widgets/feed.py
+++ b/devskim/widgets/feed.py
@@ -11,12 +11,10 @@ class FeedList(ListView):
     DEFAULT_CSS = """
     FeedList {
         height: 1fr;
-        background: transparent;
     }
     FeedList ListItem {
         height: 3;
         padding: 0;
-        background: transparent;
     }
     FeedList ListItem.-highlight {
         background: $primary-darken-2;

--- a/devskim/widgets/post_split_modal.py
+++ b/devskim/widgets/post_split_modal.py
@@ -61,7 +61,6 @@ class PostSplitModal(ModalScreen):
     PostSplitModal > Vertical {
         width: 96%;
         height: 90%;
-        background: $surface;
         border: thick $primary;
     }
     PostSplitModal #split-header {

--- a/devskim/widgets/post_split_modal.py
+++ b/devskim/widgets/post_split_modal.py
@@ -61,6 +61,7 @@ class PostSplitModal(ModalScreen):
     PostSplitModal > Vertical {
         width: 96%;
         height: 90%;
+        background: transparent;
         border: thick $primary;
     }
     PostSplitModal #split-header {

--- a/devskim/widgets/post_split_modal.py
+++ b/devskim/widgets/post_split_modal.py
@@ -61,7 +61,6 @@ class PostSplitModal(ModalScreen):
     PostSplitModal > Vertical {
         width: 96%;
         height: 90%;
-        background: transparent;
         border: thick $primary;
     }
     PostSplitModal #split-header {

--- a/tests/test_app_theme.py
+++ b/tests/test_app_theme.py
@@ -1,52 +1,26 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from devskim.app import _terminal_is_dark
 from devskim.config import Config
 
-
-def _mock_stdin(isatty: bool = True) -> MagicMock:
-    m = MagicMock()
-    m.isatty.return_value = isatty
-    m.fileno.return_value = 0
-    return m
+FAKE_FD = 99
 
 
-def _mock_stdout(isatty: bool = True) -> MagicMock:
-    m = MagicMock()
-    m.isatty.return_value = isatty
-    m.fileno.return_value = 1
-    return m
-
-
-def test_terminal_is_dark_stdin_not_tty():
-    mock_stdin = _mock_stdin(isatty=False)
-    with patch("sys.stdin", mock_stdin):
-        assert _terminal_is_dark() is True
-
-
-def test_terminal_is_dark_stdout_not_tty():
-    with (
-        patch("sys.stdin", _mock_stdin()),
-        patch("sys.stdout", _mock_stdout(isatty=False)),
-    ):
-        assert _terminal_is_dark() is True
-
-
-def test_terminal_is_dark_timeout_returns_true():
-    with (
-        patch("sys.stdin", _mock_stdin()),
-        patch("sys.stdout", _mock_stdout()),
+def _osc_patches(extra_patches=None):
+    """Base patches needed for any test that reaches the ctermid/open path."""
+    return [
+        patch("os.ctermid", return_value="/dev/tty"),
+        patch("os.open", return_value=FAKE_FD),
+        patch("os.close"),
         patch("termios.tcgetattr", return_value=[]),
         patch("termios.tcsetattr"),
         patch("tty.setraw"),
         patch("os.write"),
-        patch("select.select", return_value=([], [], [])),
-    ):
-        assert _terminal_is_dark() is True
+    ]
 
 
 def _make_osc_mocks(response: bytes):
@@ -71,11 +45,31 @@ def _make_osc_mocks(response: bytes):
     return mock_select, mock_read
 
 
+def test_terminal_is_dark_windows_returns_true():
+    with patch("sys.platform", "win32"):
+        assert _terminal_is_dark() is True
+
+
+def test_terminal_is_dark_timeout_returns_true():
+    with (
+        patch("os.ctermid", return_value="/dev/tty"),
+        patch("os.open", return_value=FAKE_FD),
+        patch("os.close"),
+        patch("termios.tcgetattr", return_value=[]),
+        patch("termios.tcsetattr"),
+        patch("tty.setraw"),
+        patch("os.write"),
+        patch("select.select", return_value=([], [], [])),
+    ):
+        assert _terminal_is_dark() is True
+
+
 def test_terminal_is_dark_light_terminal():
     mock_select, mock_read = _make_osc_mocks(b"\033]11;rgb:ffff/ffff/ffff\033\\")
     with (
-        patch("sys.stdin", _mock_stdin()),
-        patch("sys.stdout", _mock_stdout()),
+        patch("os.ctermid", return_value="/dev/tty"),
+        patch("os.open", return_value=FAKE_FD),
+        patch("os.close"),
         patch("termios.tcgetattr", return_value=[]),
         patch("termios.tcsetattr"),
         patch("tty.setraw"),
@@ -89,8 +83,9 @@ def test_terminal_is_dark_light_terminal():
 def test_terminal_is_dark_dark_terminal():
     mock_select, mock_read = _make_osc_mocks(b"\033]11;rgb:0000/0000/0000\033\\")
     with (
-        patch("sys.stdin", _mock_stdin()),
-        patch("sys.stdout", _mock_stdout()),
+        patch("os.ctermid", return_value="/dev/tty"),
+        patch("os.open", return_value=FAKE_FD),
+        patch("os.close"),
         patch("termios.tcgetattr", return_value=[]),
         patch("termios.tcsetattr"),
         patch("tty.setraw"),
@@ -101,11 +96,15 @@ def test_terminal_is_dark_dark_terminal():
         assert _terminal_is_dark() is True
 
 
-def test_terminal_is_dark_exception_returns_true():
+def test_terminal_is_dark_ctermid_fails_returns_true():
+    with patch("os.ctermid", side_effect=OSError("no tty")):
+        assert _terminal_is_dark() is True
+
+
+def test_terminal_is_dark_open_fails_returns_true():
     with (
-        patch("sys.stdin", _mock_stdin()),
-        patch("sys.stdout", _mock_stdout()),
-        patch("termios.tcgetattr", side_effect=OSError("no tty")),
+        patch("os.ctermid", return_value="/dev/tty"),
+        patch("os.open", side_effect=OSError("permission denied")),
     ):
         assert _terminal_is_dark() is True
 

--- a/tests/test_app_theme.py
+++ b/tests/test_app_theme.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from devskim.app import _terminal_is_dark
+from devskim.config import Config
+
+
+def _mock_stdin(isatty: bool = True) -> MagicMock:
+    m = MagicMock()
+    m.isatty.return_value = isatty
+    m.fileno.return_value = 0
+    return m
+
+
+def _mock_stdout(isatty: bool = True) -> MagicMock:
+    m = MagicMock()
+    m.isatty.return_value = isatty
+    m.fileno.return_value = 1
+    return m
+
+
+def test_terminal_is_dark_stdin_not_tty():
+    mock_stdin = _mock_stdin(isatty=False)
+    with patch("sys.stdin", mock_stdin):
+        assert _terminal_is_dark() is True
+
+
+def test_terminal_is_dark_stdout_not_tty():
+    with (
+        patch("sys.stdin", _mock_stdin()),
+        patch("sys.stdout", _mock_stdout(isatty=False)),
+    ):
+        assert _terminal_is_dark() is True
+
+
+def test_terminal_is_dark_timeout_returns_true():
+    with (
+        patch("sys.stdin", _mock_stdin()),
+        patch("sys.stdout", _mock_stdout()),
+        patch("termios.tcgetattr", return_value=[]),
+        patch("termios.tcsetattr"),
+        patch("tty.setraw"),
+        patch("os.write"),
+        patch("select.select", return_value=([], [], [])),
+    ):
+        assert _terminal_is_dark() is True
+
+
+def _make_osc_mocks(response: bytes):
+    """Return (mock_select, mock_read) that simulate an OSC 11 terminal reply."""
+    calls = {"select": 0, "read": 0}
+
+    def mock_select(rlist, wlist, xlist, timeout):
+        calls["select"] += 1
+        if calls["select"] == 1:
+            return ([rlist[0]], [], [])
+        if calls["select"] == 2:
+            return ([rlist[0]], [], [])
+        return ([], [], [])
+
+    chunks = [response]
+
+    def mock_read(fd, n):
+        idx = calls["read"]
+        calls["read"] += 1
+        return chunks[idx] if idx < len(chunks) else b""
+
+    return mock_select, mock_read
+
+
+def test_terminal_is_dark_light_terminal():
+    mock_select, mock_read = _make_osc_mocks(b"\033]11;rgb:ffff/ffff/ffff\033\\")
+    with (
+        patch("sys.stdin", _mock_stdin()),
+        patch("sys.stdout", _mock_stdout()),
+        patch("termios.tcgetattr", return_value=[]),
+        patch("termios.tcsetattr"),
+        patch("tty.setraw"),
+        patch("os.write"),
+        patch("os.read", side_effect=mock_read),
+        patch("select.select", side_effect=mock_select),
+    ):
+        assert _terminal_is_dark() is False
+
+
+def test_terminal_is_dark_dark_terminal():
+    mock_select, mock_read = _make_osc_mocks(b"\033]11;rgb:0000/0000/0000\033\\")
+    with (
+        patch("sys.stdin", _mock_stdin()),
+        patch("sys.stdout", _mock_stdout()),
+        patch("termios.tcgetattr", return_value=[]),
+        patch("termios.tcsetattr"),
+        patch("tty.setraw"),
+        patch("os.write"),
+        patch("os.read", side_effect=mock_read),
+        patch("select.select", side_effect=mock_select),
+    ):
+        assert _terminal_is_dark() is True
+
+
+def test_terminal_is_dark_exception_returns_true():
+    with (
+        patch("sys.stdin", _mock_stdin()),
+        patch("sys.stdout", _mock_stdout()),
+        patch("termios.tcgetattr", side_effect=OSError("no tty")),
+    ):
+        assert _terminal_is_dark() is True
+
+
+def test_config_default_theme_is_auto():
+    assert Config().theme == "auto"
+
+
+@pytest.mark.parametrize("theme", ["auto", "dark", "light"])
+def test_config_theme_values(theme):
+    c = Config(theme=theme)
+    assert c.theme == theme

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -160,6 +160,28 @@ def test_save_cache_writes_timestamp(tmp_path):
     assert abs(data["ts"] - before) < 5
 
 
+def test_load_config_reads_theme(tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('theme = "light"\n')
+    with (
+        patch("devskim.config.CONFIG_PATH", config_path),
+        patch("devskim.config.CONFIG_DIR", tmp_path),
+    ):
+        config, _ = load_config()
+    assert config.theme == "light"
+
+
+def test_load_config_default_theme_is_auto(tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("")
+    with (
+        patch("devskim.config.CONFIG_PATH", config_path),
+        patch("devskim.config.CONFIG_DIR", tmp_path),
+    ):
+        config, _ = load_config()
+    assert config.theme == "auto"
+
+
 def test_resolve_cache_dir_xdg_env(tmp_path):
     with patch.dict(os.environ, {"XDG_CACHE_HOME": str(tmp_path)}, clear=False):
         result = _resolve_cache_dir()

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import pytest
 from textual.app import App, ComposeResult
-from textual.widgets import ListItem
+from textual.widgets import Label, ListItem
 
 from devskim.sources.comments import Comment
+from devskim.widgets.comments_modal import CommentsModal
 from devskim.widgets.comments_modal import CommentWidget as CommentsCommentWidget
+from devskim.widgets.content_modal import ContentModal
 from devskim.widgets.feed import FeedList
 from devskim.widgets.post_split_modal import CommentWidget as SplitCommentWidget
 from devskim.widgets.post_split_modal import PostSplitModal
@@ -231,6 +233,101 @@ async def test_story_row_render_unseen():
         assert "A Story" in result
         assert "99" in result
         assert "7" in result
+
+
+# ---------------------------------------------------------------------------
+# FeedList.mark_current_seen — needs DOM
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_feedlist_mark_current_seen():
+    app = _FeedApp()
+    async with app.run_test() as pilot:
+        fl = app.query_one(FeedList)
+        fl.load_items([ITEM_HN, ITEM_REDDIT])
+        await pilot.pause()
+        fl.mark_current_seen()
+        rows = list(fl.query(StoryRow))
+        assert rows[0].seen is True
+        assert rows[1].seen is False
+
+
+@pytest.mark.asyncio
+async def test_feedlist_mark_current_seen_no_index():
+    fl = FeedList()
+    fl.mark_current_seen()  # should not raise when index is None
+
+
+# ---------------------------------------------------------------------------
+# ContentModal — compose
+# ---------------------------------------------------------------------------
+
+ITEM_WITH_BODY = {**ITEM_HN, "body": "## Some body\n\nParagraph here."}
+
+
+@pytest.mark.asyncio
+async def test_content_modal_composes():
+    class _App(App):
+        def compose(self) -> ComposeResult:
+            yield ContentModal(ITEM_WITH_BODY, "#ff6600")
+
+    async with _App().run_test() as _:
+        pass  # compose without error is sufficient
+
+
+@pytest.mark.asyncio
+async def test_content_modal_title_shown():
+    class _App(App):
+        def compose(self) -> ComposeResult:
+            yield ContentModal(ITEM_WITH_BODY, "#ff6600")
+
+    app = _App()
+    async with app.run_test():
+        title_label = app.query_one("#modal-title", Label)
+        assert "Test Story" in str(title_label.render())
+
+
+# ---------------------------------------------------------------------------
+# CommentsModal — compose (comments fetch mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_comments_modal_composes():
+    from unittest.mock import AsyncMock, patch
+
+    class _App(App):
+        def compose(self) -> ComposeResult:
+            yield CommentsModal(ITEM_HN, "#ff6600")
+
+    with patch(
+        "devskim.widgets.comments_modal.CommentsModal._load_comments",
+        new_callable=lambda: lambda self: AsyncMock(return_value=None)(),
+    ):
+        async with _App().run_test():
+            pass
+
+
+@pytest.mark.asyncio
+async def test_comments_modal_title_shown():
+    from unittest.mock import AsyncMock, patch
+
+    class _App(App):
+        def compose(self) -> ComposeResult:
+            yield CommentsModal(ITEM_HN, "#ff6600")
+
+    with patch(
+        "devskim.widgets.comments_modal.CommentsModal._load_comments",
+        new=AsyncMock(return_value=None),
+    ):
+        app = _App()
+        async with app.run_test():
+            title = app.query_one("#modal-title", Label)
+            assert "Test Story" in str(title.render())
+
+
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Remove `background: $surface` from `Screen`, `FeedList`, `FeedList ListItem`, and all modal containers — terminal background now shows through
- Replace hardcoded `color: #ff6600` on `LoadingIndicator` with `$accent` design token
- Source badge colors (HN orange, lobste.rs red, GitHub green) unchanged — those are semantic, not theme colors

## Test plan

- [x] Launch devskim with a dark terminal theme — background should be terminal color, not Textual's surface
- [ ] Launch with a light terminal theme — same
- [ ] Loading spinner should pick up theme accent color
- [ ] Split view / comment / content modals show terminal background through their panels
- [x] All 167 tests pass, ruff + mypy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable theme option (auto/light/dark) to control app appearance.

* **Style**
  * Switched modal, screen, and list backgrounds to transparent for cleaner integration.
  * Loading indicator now uses the app accent color for consistent theming.
  * Refined feed list and list-item visuals while preserving highlights and spacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emarkou/devskim/pull/27)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->