### PR TITLE
feat: custom browser command config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Run `devskim` — changes take effect on next launch or press `r` to refresh.
 | `github_trending_language` | `""` | Filter by language (e.g. `"python"`), empty = all |
 | `github_trending_since` | `"daily"` | Trending window: `daily`, `weekly`, or `monthly` |
 | `cache_ttl_minutes` | `10` | Minutes before refreshing cache |
+| `theme` | `"auto"` | Color theme: `auto` (detect terminal), `dark`, `light`, or any Textual theme name (`nord`, `dracula`, `solarized-light`, …) |
+| `browser` | `""` | Browser command for opening URLs (e.g. `"firefox"`, `"open -a Safari"`). Empty = system default |
 
 ## Tech stack
 

--- a/devskim/app.py
+++ b/devskim/app.py
@@ -187,8 +187,13 @@ class DevSkimApp(App):
         self.run_worker(self._load_all(), exclusive=True, name="fetch")
 
     def open_url(self, url: str, *, new_tab: bool = True) -> None:
-        if self.config.browser:
-            subprocess.Popen(shlex.split(self.config.browser) + [url])
+        browser = self.config.browser.strip()
+        if browser:
+            try:
+                subprocess.Popen(shlex.split(browser) + [url])
+            except (ValueError, OSError) as exc:
+                self.notify(f"Browser error: {exc}", severity="error")
+                super().open_url(url, new_tab=new_tab)
         else:
             super().open_url(url, new_tab=new_tab)
 

--- a/devskim/app.py
+++ b/devskim/app.py
@@ -4,6 +4,8 @@ import asyncio
 import math
 import os
 import select
+import shlex
+import subprocess
 import sys
 import time as _time
 
@@ -183,6 +185,12 @@ class DevSkimApp(App):
         self.theme = self._textual_theme
         self.query_one("#feed").display = False
         self.run_worker(self._load_all(), exclusive=True, name="fetch")
+
+    def open_url(self, url: str, *, new_tab: bool = True) -> None:
+        if self.config.browser:
+            subprocess.Popen(shlex.split(self.config.browser) + [url])
+        else:
+            super().open_url(url, new_tab=new_tab)
 
     async def _load_all(self) -> None:
         """Fetch all sources concurrently; render each source's items as they arrive."""

--- a/devskim/config.py
+++ b/devskim/config.py
@@ -54,6 +54,7 @@ github_trending_count = 25
 # github_trending_since = "daily"       # daily | weekly | monthly
 cache_ttl_minutes = 10
 # theme = "auto"                        # auto (default), dark, or light
+# browser = ""                          # e.g. "firefox", "open -a Safari" (default: system browser)
 """
 
 
@@ -72,6 +73,7 @@ class Config:
     github_trending_since: str = "daily"
     cache_ttl_minutes: int = 10
     theme: str = "auto"
+    browser: str = ""
 
 
 def load_config() -> tuple[Config, bool]:
@@ -93,6 +95,7 @@ def load_config() -> tuple[Config, bool]:
         github_trending_since=str(raw.get("github_trending_since", "daily")),
         cache_ttl_minutes=int(raw.get("cache_ttl_minutes", 10)),
         theme=str(raw.get("theme", "auto")),
+        browser=str(raw.get("browser", "")),
     ), created
 
 

--- a/tests/test_app_theme.py
+++ b/tests/test_app_theme.py
@@ -161,3 +161,43 @@ async def test_open_url_default_browser_calls_super():
         async with app.run_test():
             app.open_url("https://example.com")
     mock_super.assert_called_once_with("https://example.com", new_tab=True)
+
+
+@pytest.mark.asyncio
+async def test_open_url_whitespace_browser_falls_back_to_super():
+    config = Config(browser="   ")
+    app = DevSkimApp(config)
+    with (
+        patch("devskim.app._terminal_is_dark", return_value=True),
+        patch("textual.app.App.open_url") as mock_super,
+    ):
+        async with app.run_test():
+            app.open_url("https://example.com")
+    mock_super.assert_called_once_with("https://example.com", new_tab=True)
+
+
+@pytest.mark.asyncio
+async def test_open_url_oserror_falls_back_to_super():
+    config = Config(browser="notabrowser")
+    app = DevSkimApp(config)
+    with (
+        patch("devskim.app._terminal_is_dark", return_value=True),
+        patch("devskim.app.subprocess.Popen", side_effect=OSError("not found")),
+        patch("textual.app.App.open_url") as mock_super,
+    ):
+        async with app.run_test():
+            app.open_url("https://example.com")
+    mock_super.assert_called_once_with("https://example.com", new_tab=True)
+
+
+@pytest.mark.asyncio
+async def test_open_url_valueerror_falls_back_to_super():
+    config = Config(browser="'unclosed")
+    app = DevSkimApp(config)
+    with (
+        patch("devskim.app._terminal_is_dark", return_value=True),
+        patch("textual.app.App.open_url") as mock_super,
+    ):
+        async with app.run_test():
+            app.open_url("https://example.com")
+    mock_super.assert_called_once_with("https://example.com", new_tab=True)

--- a/tests/test_app_theme.py
+++ b/tests/test_app_theme.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from devskim.app import _terminal_is_dark
+from devskim.app import DevSkimApp, _terminal_is_dark
 from devskim.config import Config
 
 FAKE_FD = 99
@@ -117,3 +117,47 @@ def test_config_default_theme_is_auto():
 def test_config_theme_values(theme):
     c = Config(theme=theme)
     assert c.theme == theme
+
+
+# ---------------------------------------------------------------------------
+# DevSkimApp.open_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_url_custom_browser():
+    config = Config(browser="mybrowser")
+    app = DevSkimApp(config)
+    with (
+        patch("devskim.app.subprocess.Popen") as mock_popen,
+        patch("devskim.app._terminal_is_dark", return_value=True),
+    ):
+        async with app.run_test():
+            app.open_url("https://example.com")
+    mock_popen.assert_called_once_with(["mybrowser", "https://example.com"])
+
+
+@pytest.mark.asyncio
+async def test_open_url_custom_browser_with_args():
+    config = Config(browser="open -a Safari")
+    app = DevSkimApp(config)
+    with (
+        patch("devskim.app.subprocess.Popen") as mock_popen,
+        patch("devskim.app._terminal_is_dark", return_value=True),
+    ):
+        async with app.run_test():
+            app.open_url("https://example.com")
+    mock_popen.assert_called_once_with(["open", "-a", "Safari", "https://example.com"])
+
+
+@pytest.mark.asyncio
+async def test_open_url_default_browser_calls_super():
+    config = Config(browser="")
+    app = DevSkimApp(config)
+    with (
+        patch("devskim.app._terminal_is_dark", return_value=True),
+        patch("textual.app.App.open_url") as mock_super,
+    ):
+        async with app.run_test():
+            app.open_url("https://example.com")
+    mock_super.assert_called_once_with("https://example.com", new_tab=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,6 +182,21 @@ def test_load_config_default_theme_is_auto(tmp_path):
     assert config.theme == "auto"
 
 
+def test_config_default_browser_is_empty():
+    assert Config().browser == ""
+
+
+def test_load_config_reads_browser(tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('browser = "firefox"\n')
+    with (
+        patch("devskim.config.CONFIG_PATH", config_path),
+        patch("devskim.config.CONFIG_DIR", tmp_path),
+    ):
+        config, _ = load_config()
+    assert config.browser == "firefox"
+
+
 def test_resolve_cache_dir_xdg_env(tmp_path):
     with patch.dict(os.environ, {"XDG_CACHE_HOME": str(tmp_path)}, clear=False):
         result = _resolve_cache_dir()


### PR DESCRIPTION
## Summary

- Add `browser` config key to `~/.config/devskim/config.toml`
- When set, URLs are opened with that command instead of the system default
- Supports commands with arguments (e.g. `"open -a Safari"`, `"firefox --private-window"`)
- Empty string (default) falls back to existing system browser behavior

## Usage

```toml
browser = "firefox"
# or
browser = "open -a Safari"
# or
browser = "firefox --private-window"
```

## Test plan

- [ ] `browser = "firefox"` → `firefox <url>` spawned on `o` keypress
- [ ] `browser = "open -a Safari"` → args split correctly
- [ ] `browser = ""` → system default browser used (existing behavior unchanged)
- [ ] 190 tests pass, ruff + mypy clean, coverage 74% → 79%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "browser" config to specify a custom command template for opening URLs; empty value uses the system default
  * Browser command strings with arguments are correctly parsed and launched; failures fall back to the default opener

* **Documentation**
  * README updated to document the new "browser" setting and the "theme" option (auto/dark/light/named themes)

* **Tests**
  * Added coverage for custom browser behavior, fallback cases, and config parsing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emarkou/devskim/pull/28)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->